### PR TITLE
Define PolyForm Shield license (closes #13)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,73 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-# PolyForm Noncommercial License 1.0.0
+# PolyForm Shield License 1.0.0
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+<https://polyformproject.org/licenses/shield/1.0.0>
 
 ## Acceptance
 
@@ -28,17 +28,27 @@ The licensor grants you an additional copyright license to make changes and new 
 
 The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
 
-## Noncommercial Purposes
+## Noncompete
 
-Any noncommercial purpose is a permitted purpose.
+Any purpose is a permitted purpose, except for providing any product that competes with the software or any product the licensor or any of its affiliates provides using the software.
 
-## Personal Uses
+## Competition
 
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+Goods and services compete even when they provide functionality through different kinds of interfaces or for different technical platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a product as a practical substitute for the software or another product, it definitely competes.
 
-## Noncommercial Organizations
+## New Products
 
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+If you are using the software to provide a product that does not compete, but the licensor or any of its affiliates brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
+
+## Discontinued Products
+
+You may begin using the software to compete with a product or service that the licensor or any of its affiliates has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
+
+> Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
+
+## Sales of Business
+
+If the licensor or any of its affiliates sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete) for that product.
 
 ## Fair Use
 
@@ -64,9 +74,15 @@ The first time you are notified in writing that you have violated any of these t
 
 The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
 
+A **product** can be a good or service, or a combination of them.
+
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ The licensor grants you an additional copyright license to distribute copies of 
 
 You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+> Required Notice: Copyright 2026 Shugo Kawamura / Mikansei Laboratory (https://github.com/MikanseiLaboratory)
 
 ## Changes and New Works License
 
@@ -44,7 +44,7 @@ If you are using the software to provide a product that does not compete, but th
 
 You may begin using the software to compete with a product or service that the licensor or any of its affiliates has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
 
-> Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
+> Licensor Line of Business: eiviz multi M/E vision mixer (https://github.com/MikanseiLaboratory/eiviz)
 
 ## Sales of Business
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Required Notice: Copyright 2026 MikanseiLaboratory (https://github.com/MikanseiLaboratory)

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Required Notice: Copyright 2026 MikanseiLaboratory (https://github.com/MikanseiLaboratory)
+Required Notice: Copyright 2026 Shugo Kawamura / Mikansei Laboratory (https://github.com/MikanseiLaboratory)

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,2 @@
 Required Notice: Copyright 2026 Shugo Kawamura / Mikansei Laboratory (https://github.com/MikanseiLaboratory)
+Licensor Line of Business: eiviz multi M/E vision mixer (https://github.com/MikanseiLaboratory/eiviz)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ cargo test --manifest-path mixer\Cargo.toml
 
 eiviz original source is licensed under the [PolyForm Shield License 1.0.0](LICENSE).
 
-Internal use is allowed, including at for-profit organizations. Competing with eiviz is not: shipping a vision mixer (paid or free) that is a practical substitute for this software, or for another product Shugo Kawamura / Mikansei Laboratory provides using it. A separate license from the copyright holders is required for that.
+Internal use is allowed, including at for-profit organizations. Competing with eiviz is not: shipping a vision mixer (paid or free) that is a practical substitute for this software, or for another product Shugo Kawamura / Mikansei Laboratory provides using it. A separate license from Shugo Kawamura / Mikansei Laboratory is required for that.
 
 Third-party crates and libraries stay under their original MIT / Apache-2.0 / Zlib terms. See [NOTICE](NOTICE) and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ cargo test --manifest-path mixer\Cargo.toml
 
 eiviz original source is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
 
-Non-commercial use is allowed: personal, hobby, education, research, and use by qualifying noncommercial organizations. Selling eiviz, bundling it as a product, or other commercial purposes are not allowed under this license. A separate commercial license from the copyright holder is required for those uses.
+Non-commercial use is allowed: personal, hobby, education, research, and use by qualifying noncommercial organizations. Selling eiviz, bundling it as a product, or other commercial purposes are not allowed under this license. A separate commercial license from Shugo Kawamura / Mikansei Laboratory is required for those uses.
 
 Third-party crates and libraries stay under their original MIT / Apache-2.0 / Zlib terms. See [NOTICE](NOTICE) and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ dotnet build eiviz.slnx -c Release
 dotnet run --project host\Eiviz.Host.csproj -c Release
 cargo test --manifest-path mixer\Cargo.toml
 ```
+
+## License
+
+eiviz original source is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+Non-commercial use is allowed: personal, hobby, education, research, and use by qualifying noncommercial organizations. Selling eiviz, bundling it as a product, or other commercial purposes are not allowed under this license. A separate commercial license from the copyright holder is required for those uses.
+
+Third-party crates and libraries stay under their original MIT / Apache-2.0 / Zlib terms. See [NOTICE](NOTICE) and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ cargo test --manifest-path mixer\Cargo.toml
 
 ## License
 
-eiviz original source is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+eiviz original source is licensed under the [PolyForm Shield License 1.0.0](LICENSE).
 
-Non-commercial use is allowed: personal, hobby, education, research, and use by qualifying noncommercial organizations. Selling eiviz, bundling it as a product, or other commercial purposes are not allowed under this license. A separate commercial license from Shugo Kawamura / Mikansei Laboratory is required for those uses.
+Internal use is allowed, including at for-profit organizations. Competing with eiviz is not: shipping a vision mixer (paid or free) that is a practical substitute for this software, or for another product Shugo Kawamura / Mikansei Laboratory provides using it. A separate license from the copyright holders is required for that.
 
 Third-party crates and libraries stay under their original MIT / Apache-2.0 / Zlib terms. See [NOTICE](NOTICE) and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-eiviz original source is licensed under the PolyForm Noncommercial License 1.0.0.
+eiviz original source is licensed under the PolyForm Shield License 1.0.0.
 See `LICENSE` and `NOTICE`.
 
 This file covers components that eiviz uses but does **not** relicense.
@@ -43,7 +43,7 @@ interface. It does not redistribute Steinberg's ASIO SDK.
 ASIO is a trademark of Steinberg Media Technologies GmbH. Using the ASIO
 name or shipping an ASIO-enabled **commercial** product may require a
 separate arrangement with Steinberg. That is independent of this
-repository's PolyForm Noncommercial terms.
+repository's PolyForm Shield terms.
 
 ## Binary releases
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,52 @@
+# Third-party notices
+
+eiviz original source is licensed under the PolyForm Noncommercial License 1.0.0.
+See `LICENSE` and `NOTICE`.
+
+This file covers components that eiviz uses but does **not** relicense.
+Those components stay under their own terms. Permissive licenses (MIT,
+Apache-2.0, Zlib) allow use inside a more restrictive application as long
+as copyright and permission notices are preserved.
+
+## Direct Rust dependencies (`mixer/Cargo.toml`)
+
+| Crate | License | Source |
+| --- | --- | --- |
+| bytemuck | MIT OR Apache-2.0 | https://crates.io/crates/bytemuck |
+| image | MIT OR Apache-2.0 | https://crates.io/crates/image |
+| openmediatransport | MIT | https://github.com/MikanseiLaboratory/openmediatransport-rs |
+| pollster | Apache-2.0 OR MIT | https://crates.io/crates/pollster |
+| raw-window-handle | MIT OR Apache-2.0 OR Zlib | https://crates.io/crates/raw-window-handle |
+| thiserror | MIT OR Apache-2.0 | https://crates.io/crates/thiserror |
+| vmx | MIT | https://github.com/MikanseiLaboratory/vmx-rs |
+| wgpu | MIT OR Apache-2.0 | https://crates.io/crates/wgpu |
+| windows | MIT OR Apache-2.0 | https://crates.io/crates/windows |
+
+Transitive crates pulled by the above (for example naga, png, parking_lot)
+are also MIT and/or Apache-2.0. Full versions are pinned in `mixer/Cargo.lock`.
+
+Official Open Media Transport libraries that those git crates independently
+reimplement (`libomtnet`, `libomt`, `libvmx`) are MIT as well. They are not
+copied into this repository.
+
+## Host (C# / WPF)
+
+The host targets .NET on Windows and uses WPF. Those platform components
+are distributed by Microsoft under their own terms (typically MIT for the
+.NET SDK/runtime sources). This repository does not vendor the .NET runtime.
+
+## ASIO trademark
+
+eiviz talks to installed ASIO drivers through the public COM `IASIO`
+interface. It does not redistribute Steinberg's ASIO SDK.
+
+ASIO is a trademark of Steinberg Media Technologies GmbH. Using the ASIO
+name or shipping an ASIO-enabled **commercial** product may require a
+separate arrangement with Steinberg. That is independent of this
+repository's PolyForm Noncommercial terms.
+
+## Binary releases
+
+A binary build includes compiled third-party code. Keep this file, `LICENSE`,
+and `NOTICE` next to the executable (or in the release archive) so MIT and
+Apache-2.0 notice requirements stay satisfied.

--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -8,8 +8,8 @@
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
-    <Authors>MikanseiLaboratory</Authors>
-    <Copyright>Copyright 2026 MikanseiLaboratory</Copyright>
+    <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
+    <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Noncommercial-1.0.0</PackageLicenseExpression>
     <MixerProject>$(MSBuildThisFileDirectory)..\mixer</MixerProject>
     <MixerLibrary>$(MixerProject)\target\release\eiviz_mixer.dll</MixerLibrary>

--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -10,7 +10,7 @@
     <LangVersion>preview</LangVersion>
     <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
-    <PackageLicenseExpression>PolyForm-Noncommercial-1.0.0</PackageLicenseExpression>
+    <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
     <MixerProject>$(MSBuildThisFileDirectory)..\mixer</MixerProject>
     <MixerLibrary>$(MixerProject)\target\release\eiviz_mixer.dll</MixerLibrary>
   </PropertyGroup>

--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -8,6 +8,9 @@
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
+    <Authors>MikanseiLaboratory</Authors>
+    <Copyright>Copyright 2026 MikanseiLaboratory</Copyright>
+    <PackageLicenseExpression>PolyForm-Noncommercial-1.0.0</PackageLicenseExpression>
     <MixerProject>$(MSBuildThisFileDirectory)..\mixer</MixerProject>
     <MixerLibrary>$(MixerProject)\target\release\eiviz_mixer.dll</MixerLibrary>
   </PropertyGroup>

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -3,6 +3,7 @@ name = "eiviz_mixer"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.97"
+authors = ["Shugo Kawamura", "Mikansei Laboratory"]
 license = "PolyForm-Noncommercial-1.0.0"
 
 [lib]

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.97"
 authors = ["Shugo Kawamura", "Mikansei Laboratory"]
-license = "PolyForm-Noncommercial-1.0.0"
+license = "PolyForm-Shield-1.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -3,6 +3,7 @@ name = "eiviz_mixer"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.97"
+license = "PolyForm-Noncommercial-1.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Issue #13 listed MIT or Apache-2.0. Those licenses allow shipping a competing product, so they cannot satisfy the request to restrict 商品利用.

Internal use is allowed. The restriction is competing products, not commercial activity in general.

## Copyright holders

**Shugo Kawamura / Mikansei Laboratory**

GitHub org slug `MikanseiLaboratory` is only used in repository URLs. The legal names in `NOTICE`, `LICENSE` example lines, and package metadata are `Shugo Kawamura` and `Mikansei Laboratory`.

## Recommendation

**PolyForm Shield License 1.0.0** for original eiviz source.

| Candidate | Internal commercial use | Competing product | Fit |
| --- | --- | --- | --- |
| MIT / Apache-2.0 | Allowed | Allowed | Too open |
| PolyForm Noncommercial 1.0.0 | Forbidden | Forbidden | Too strict (blocks in-house production) |
| **PolyForm Shield 1.0.0** | Allowed | Forbidden | Matches current intent |

## Compatibility (no relicensing of dependencies)

Direct mixer dependencies and the first-party git crates (`openmediatransport-rs`, `vmx-rs`) are MIT and/or Apache-2.0 (raw-window-handle also offers Zlib). Official OMT libraries they reimplement (`libomtnet`, `libomt`, `libvmx`) are MIT. Permissive terms allow use inside a more restrictive application **if notices are kept**. This change does not relicense those crates; `THIRD_PARTY_NOTICES.md` records that.

## What this license allows / forbids

Allowed: personal, hobby, education, research, and **internal use at for-profit organizations** (for example in-house production).

Not allowed: providing a product that competes with eiviz, or with another product the copyright holders provide using eiviz — including a free substitute. A separate license from Shugo Kawamura / Mikansei Laboratory is required for that.

`NOTICE` (and the corresponding example lines in `LICENSE`) include `Licensor Line of Business: eiviz multi M/E vision mixer` so the noncompete still applies if the product is later discontinued.

## Files

- `LICENSE` — PolyForm Shield 1.0.0, with sample Yoyodyne lines replaced by the actual rights holders
- `NOTICE` — copyright line + line of business
- `THIRD_PARTY_NOTICES.md` — dependency licenses + ASIO trademark note
- `README.md`, `mixer/Cargo.toml`, `host/Eiviz.Host.csproj` — license metadata

Closes #13.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04765-eaa5-7d67-bf78-e30bc48bfaba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04765-eaa5-7d67-bf78-e30bc48bfaba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

