### PR TITLE
Add Windows x64 GitHub Actions CI and tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+# Windows x64 CI (first supported target). See #10.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  DOTNET_NOLOGO: "1"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+jobs:
+  windows-x64:
+    name: Test and build (Windows x64)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust 1.97
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.0
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: mixer
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Test mixer
+        working-directory: mixer
+        # mixer_create is process-global, so GPU/integration tests cannot share the process.
+        run: cargo test --locked --release -- --test-threads=1
+
+      - name: Build host
+        run: dotnet build eiviz.slnx -c Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+# GitHub Releases for version tags. See #10.
+#   v1.2.3           -> Release
+#   v1.2.3-alpha.1   -> Pre-release
+#   v1.2.3-beta.1    -> Pre-release
+#   v1.2.3-rc.1      -> Pre-release
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and publish (e.g. v0.0.0-alpha.1)"
+        required: true
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  DOTNET_NOLOGO: "1"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+jobs:
+  windows-x64:
+    name: Release Windows x64
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Resolve tag
+        id: meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          TAG="${TAG#refs/tags/}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)([.-].*)?)?$ ]]; then
+            echo "Unsupported tag '$TAG'. Expected vX.Y.Z or vX.Y.Z-(alpha|beta|rc)[...]" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          BASE="${VERSION%%-*}"
+          if [[ "$TAG" =~ -(alpha|beta|rc)([.-]|$) ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Resolved $TAG (assembly $BASE, prerelease=$PRERELEASE)"
+
+      - name: Install Rust 1.97
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.0
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: mixer
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Test mixer
+        working-directory: mixer
+        run: cargo test --locked --release -- --test-threads=1
+
+      - name: Publish host (win-x64)
+        run: |
+          dotnet publish host\Eiviz.Host.csproj `
+            -c Release `
+            -r win-x64 `
+            --self-contained true `
+            -o "${{ github.workspace }}\publish\win-x64" `
+            -p:Version=${{ steps.meta.outputs.base }} `
+            -p:InformationalVersion=${{ steps.meta.outputs.version }}
+          if (-not (Test-Path "${{ github.workspace }}\publish\win-x64\Eiviz.Host.exe")) {
+            throw "Published output is missing Eiviz.Host.exe"
+          }
+          if (-not (Test-Path "${{ github.workspace }}\publish\win-x64\eiviz_mixer.dll")) {
+            throw "Published output is missing eiviz_mixer.dll"
+          }
+
+      - name: Package zip
+        shell: bash
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          STAGING="eiviz-${TAG}-win-x64"
+          mkdir -p "$STAGING"
+          cp -a publish/win-x64/. "$STAGING/"
+          7z a -tzip "${STAGING}.zip" "$STAGING"
+          sha256sum "${STAGING}.zip" | tee "${STAGING}.zip.sha256"
+
+      - name: Upload GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
+          make_latest: ${{ steps.meta.outputs.prerelease != 'true' }}
+          generate_release_notes: true
+          files: |
+            eiviz-${{ steps.meta.outputs.tag }}-win-x64.zip
+            eiviz-${{ steps.meta.outputs.tag }}-win-x64.zip.sha256

--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -16,4 +16,8 @@
     <Exec Command="cargo build --release" WorkingDirectory="$(MixerProject)" />
     <Copy SourceFiles="$(MixerLibrary)" DestinationFolder="$(OutDir)" />
   </Target>
+
+  <Target Name="PublishMixer" AfterTargets="Publish">
+    <Copy SourceFiles="$(MixerLibrary)" DestinationFolder="$(PublishDir)" />
+  </Target>
 </Project>

--- a/mixer/src/dxgi.rs
+++ b/mixer/src/dxgi.rs
@@ -76,25 +76,43 @@ impl DxgiVideo {
                 })
                 .map_err(|e| e.to_string())?
         };
-        let flags = (D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT).0;
+        let flags_video = (D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT).0;
+        let flags_basic = D3D11_CREATE_DEVICE_BGRA_SUPPORT.0;
         let levels = [D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0];
         let queue_unknown: IUnknown = queue_11on12.cast().map_err(|e| e.to_string())?;
         let queues = [Some(queue_unknown)];
         let mut d3d11 = None;
         let mut context = None;
         let mut chosen = D3D_FEATURE_LEVEL::default();
+        // WARP / VMs (GitHub-hosted runners) reject VIDEO_SUPPORT (DXGI_ERROR_UNSUPPORTED).
+        // Compose and OMT still work without DXVA; file/UVC GPU import can fall back to CPU.
         unsafe {
-            D3D11On12CreateDevice(
+            if let Err(error) = D3D11On12CreateDevice(
                 &device12,
-                flags,
+                flags_video,
                 Some(&levels),
                 Some(&queues),
                 0,
                 Some(&mut d3d11),
                 Some(&mut context),
                 Some(&mut chosen),
-            )
-            .map_err(|e| e.to_string())?;
+            ) {
+                eprintln!("eiviz dxgi video: {error}; retrying without video support");
+                d3d11 = None;
+                context = None;
+                chosen = D3D_FEATURE_LEVEL::default();
+                D3D11On12CreateDevice(
+                    &device12,
+                    flags_basic,
+                    Some(&levels),
+                    Some(&queues),
+                    0,
+                    Some(&mut d3d11),
+                    Some(&mut context),
+                    Some(&mut chosen),
+                )
+                .map_err(|e| e.to_string())?;
+            }
         }
         let d3d11 = d3d11.ok_or("D3D11On12 device")?;
         let context = context.ok_or("D3D11On12 context")?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #10

main の Windows ファースト構成に合わせて、GitHub Actions でテストとリリースを回せるようにしました。

## 内容

- **CI** (`.github/workflows/ci.yml`)
  - `main` への push と pull request で Windows x64 を実行
  - Rust 1.97 + .NET 10
  - `cargo test --locked --release -- --test-threads=1`（mixer はプロセスグローバルなので並列不可）
  - `dotnet build eiviz.slnx -c Release`

- **Release** (`.github/workflows/release.yml`)
  - `vX.Y.Z` → GitHub Release
  - `vX.Y.Z-alpha.1` / `-beta.1` / `-rc.1` → Pre-release（Latest にはしない）
  - self-contained の `win-x64` zip（`Eiviz.Host.exe` + `eiviz_mixer.dll`）と SHA-256 を添付
  - 既存タグからの手動実行（workflow_dispatch）にも対応

- **Host**
  - `dotnet publish` 時に `eiviz_mixer.dll` を publish ディレクトリへコピー

- **Mixer (CI 向け)**
  - GitHub-hosted runner の WARP は `D3D11_CREATE_DEVICE_VIDEO_SUPPORT` を拒否するため、失敗時はビデオなしの D3D11On12 で再試行します。合成 / OMT テストは動き、ファイル/UVC の GPU import は CPU に落ちます。

## 使い方

```text
git tag v0.0.0-alpha.1
git push origin v0.0.0-alpha.1   # Pre-release

git tag v0.0.0
git push origin v0.0.0           # Release
```

ファーストターゲットは Windows x64 のみです。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04765-187c-7e14-af26-3b1855a955d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04765-187c-7e14-af26-3b1855a955d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

