### PR TITLE
Add default NDI input and output via grafton-ndi

### DIFF
--- a/.github/actions/setup-ndi-windows/action.yml
+++ b/.github/actions/setup-ndi-windows/action.yml
@@ -1,0 +1,104 @@
+name: Setup NDI SDK on Windows
+description: Install NDI SDK 6 and LLVM so grafton-ndi can build on Windows x64
+inputs:
+  save-cache:
+    description: Whether to save the cache after installation
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Generate cache key
+      id: cache-key
+      shell: pwsh
+      run: |
+        # downloads.ndi.tv can rotate the installer for the same URL.
+        $primary = '4D5DD36A1C7C7634F408BF459B068787CCE6F5310A3EFE832D76B1DDEB54E499'
+        $previous = '97E8993C6B94213A950E6ACBE9AA4D35831D137324D762F7C74851D3FEEF80D9'
+        $ndiHash = $primary.Substring(0, 8)
+        $llvm = if ($env:LLVM_VERSION) { $env:LLVM_VERSION } else { '20.1.8' }
+        echo "key=eiviz-ndi-v1-$ndiHash-$llvm-${{ runner.os }}" >> $env:GITHUB_OUTPUT
+        echo "accepted_hashes=$primary,$previous" >> $env:GITHUB_OUTPUT
+        echo "llvm_version=$llvm" >> $env:GITHUB_OUTPUT
+
+    - name: Restore cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ${{ runner.temp }}\ndi-sdk\**\*
+          C:\Program Files\LLVM
+        key: ${{ steps.cache-key.outputs.key }}
+
+    - name: Install LLVM
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        if (Test-Path "C:\Program Files\LLVM\bin\clang.exe") {
+          Write-Host "LLVM already installed"
+        } else {
+          choco install llvm --version=${{ steps.cache-key.outputs.llvm_version }} -y
+        }
+
+    - name: Download and install NDI SDK
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $NDI_SDK_DIR = "${{ runner.temp }}\ndi-sdk"
+        $NDI_SDK_INSTALLER = "${{ runner.temp }}\NDI_SDK_Installer.exe"
+        $url = if ($env:NDI_SDK_URL) { $env:NDI_SDK_URL } else { 'https://downloads.ndi.tv/SDK/NDI_SDK/NDI%206%20SDK.exe' }
+
+        Write-Host "Downloading NDI SDK..."
+        curl.exe -L --retry 4 --retry-delay 8 -o "$NDI_SDK_INSTALLER" "$url"
+
+        Write-Host "Verifying NDI SDK integrity..."
+        $accepted = '${{ steps.cache-key.outputs.accepted_hashes }}' -split ',' | ForEach-Object { $_.Trim().ToUpperInvariant() } | Where-Object { $_ }
+        $actual = (Get-FileHash "$NDI_SDK_INSTALLER" -Algorithm SHA256).Hash
+        if ($accepted -notcontains $actual) {
+          Write-Error "NDI SDK hash mismatch! Got: $actual. Accepted: $($accepted -join ', ')"
+          exit 1
+        }
+        Write-Host "NDI SDK hash verified: $actual"
+
+        Write-Host "Installing NDI SDK to: $NDI_SDK_DIR"
+        $proc = Start-Process -FilePath "$NDI_SDK_INSTALLER" `
+          -ArgumentList "/VERYSILENT", "/SP-", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOCANCEL", "/DIR=$NDI_SDK_DIR", "/LOG=$env:TEMP\ndi_install.log" `
+          -PassThru
+        if (!$proc.WaitForExit(300000)) {
+          $proc | Stop-Process -Force
+          if (-not (Test-Path "$NDI_SDK_DIR\include\Processing.NDI.Lib.h")) {
+            Write-Error "NDI SDK installation timed out"
+            exit 1
+          }
+        } elseif ($proc.ExitCode -ne 0) {
+          Write-Error "NDI installer failed with code $($proc.ExitCode)"
+          exit 1
+        }
+
+        Remove-Item "$NDI_SDK_INSTALLER" -ErrorAction SilentlyContinue
+        if (-not (Test-Path "$NDI_SDK_DIR\include\Processing.NDI.Lib.h")) {
+          Write-Error "NDI SDK installation failed - header file not found"
+          exit 1
+        }
+
+    - name: Setup environment
+      shell: pwsh
+      run: |
+        $sdk = "${{ runner.temp }}\ndi-sdk"
+        if (-not (Test-Path "$sdk\include\Processing.NDI.Lib.h")) {
+          Write-Error "NDI SDK header missing at $sdk"
+          exit 1
+        }
+        "NDI_SDK_DIR=$sdk" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+        "$sdk\Bin\x64" | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+        "C:\Program Files\LLVM\bin" | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+        "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
+    - name: Save cache
+      if: inputs.save-cache == 'true' && steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ runner.temp }}\ndi-sdk\**\*
+          C:\Program Files\LLVM
+        key: ${{ steps.cache-key.outputs.key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ env:
   CARGO_INCREMENTAL: "0"
   DOTNET_NOLOGO: "1"
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  NDI_SDK_URL: https://downloads.ndi.tv/SDK/NDI_SDK/NDI%206%20SDK.exe
+  LLVM_VERSION: "20.1.8"
 
 jobs:
   windows-x64:
@@ -28,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Setup NDI SDK and LLVM
+        uses: ./.github/actions/setup-ndi-windows
 
       - name: Install Rust 1.97
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ env:
   CARGO_INCREMENTAL: "0"
   DOTNET_NOLOGO: "1"
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  NDI_SDK_URL: https://downloads.ndi.tv/SDK/NDI_SDK/NDI%206%20SDK.exe
+  LLVM_VERSION: "20.1.8"
 
 jobs:
   windows-x64:
@@ -38,6 +40,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup NDI SDK and LLVM
+        uses: ./.github/actions/setup-ndi-windows
 
       - name: Resolve tag
         id: meta
@@ -103,6 +108,9 @@ jobs:
           }
           if (-not (Test-Path "${{ github.workspace }}\publish\win-x64\eiviz_mixer.dll")) {
             throw "Published output is missing eiviz_mixer.dll"
+          }
+          if (-not (Test-Path "${{ github.workspace }}\publish\win-x64\Processing.NDI.Lib.x64.dll")) {
+            throw "Published output is missing Processing.NDI.Lib.x64.dll"
           }
 
       - name: Package zip

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Mix, switch, overlay, and send live video. Each Mixing Unit has Preview and Prog
 
 The mixer is Rust + wgpu (DX12). The UI is C# WPF. Proof of concept.
 
-Inputs: colour, bars, still, video file, UVC, OMT.  
-Output: OMT (GPU or CPU encode).  
+Inputs: colour, bars, still, video file, UVC, OMT, NDI®.  
+Output: OMT (GPU or CPU encode), NDI® (CPU / UYVY).  
 Scenes, overlays, multiview. Audio buses over WASAPI / ASIO.
 
 ## Build
 
-Windows, .NET 10, Rust 1.97, a DirectX 12 GPU.
+Windows, .NET 10, Rust 1.97, a DirectX 12 GPU, the [NDI SDK 6](https://ndi.video/for-developers/ndi-sdk/) (set `NDI_SDK_DIR` if it is not installed to the default path), and LLVM/Clang for bindgen.
 
 ```powershell
 dotnet build eiviz.slnx -c Release

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,6 +13,7 @@ as copyright and permission notices are preserved.
 | Crate | License | Source |
 | --- | --- | --- |
 | bytemuck | MIT OR Apache-2.0 | https://crates.io/crates/bytemuck |
+| grafton-ndi | Apache-2.0 | https://crates.io/crates/grafton-ndi |
 | image | MIT OR Apache-2.0 | https://crates.io/crates/image |
 | openmediatransport | MIT | https://github.com/MikanseiLaboratory/openmediatransport-rs |
 | pollster | Apache-2.0 OR MIT | https://crates.io/crates/pollster |
@@ -44,6 +45,16 @@ ASIO is a trademark of Steinberg Media Technologies GmbH. Using the ASIO
 name or shipping an ASIO-enabled **commercial** product may require a
 separate arrangement with Steinberg. That is independent of this
 repository's PolyForm Shield terms.
+
+## NDI®
+
+eiviz talks to NDI through [grafton-ndi](https://crates.io/crates/grafton-ndi)
+(Apache-2.0) and the NDI SDK. The NDI SDK stays under Vizrt NDI AB terms;
+this repository does not relicense it.
+
+A binary release includes `Processing.NDI.Lib.x64.dll` next to the
+executable, as the NDI SDK distribution rules require. NDI® is a registered
+trademark of Vizrt NDI AB. See https://ndi.video/.
 
 ## Binary releases
 

--- a/host/App.xaml.cs
+++ b/host/App.xaml.cs
@@ -119,15 +119,14 @@ public partial class App : Application
                             input.UseGpu,
                             input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
                             input.BandwidthSave,
-                            input.KeepFullOnMultiview));
+                            input.KeepFullOnMultiview,
+                            input.OmtQuality));
                         break;
                     case InputKind.Ndi when !string.IsNullOrWhiteSpace(input.PathOrAddress):
                         Commands.TryEnqueue(new ConnectNdiCommand(
                             input.Id,
                             input.PathOrAddress,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
-                            input.BandwidthSave,
-                            input.KeepFullOnMultiview));
+                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
                         break;
                     case InputKind.Uvc when !string.IsNullOrWhiteSpace(input.PathOrAddress):
                         Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress));

--- a/host/App.xaml.cs
+++ b/host/App.xaml.cs
@@ -77,7 +77,7 @@ public partial class App : Application
         AudioGraphSync.Push(Session);
         foreach (var output in Session.Outputs)
         {
-            if (output.Transport != OutputTransport.Omt)
+            if (output.Transport is not (OutputTransport.Omt or OutputTransport.Ndi))
                 continue;
             Commands.AddOutputNow(output);
         }
@@ -117,6 +117,12 @@ public partial class App : Application
                             input.Id,
                             input.PathOrAddress,
                             input.UseGpu,
+                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
+                        break;
+                    case InputKind.Ndi when !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                        Commands.TryEnqueue(new ConnectNdiCommand(
+                            input.Id,
+                            input.PathOrAddress,
                             input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
                         break;
                     case InputKind.Uvc when !string.IsNullOrWhiteSpace(input.PathOrAddress):

--- a/host/App.xaml.cs
+++ b/host/App.xaml.cs
@@ -126,7 +126,8 @@ public partial class App : Application
                         Commands.TryEnqueue(new ConnectNdiCommand(
                             input.Id,
                             input.PathOrAddress,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
+                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+                            input.NdiBandwidth));
                         break;
                     case InputKind.Uvc when !string.IsNullOrWhiteSpace(input.PathOrAddress):
                         Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress));

--- a/host/App.xaml.cs
+++ b/host/App.xaml.cs
@@ -117,13 +117,17 @@ public partial class App : Application
                             input.Id,
                             input.PathOrAddress,
                             input.UseGpu,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
+                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+                            input.BandwidthSave,
+                            input.KeepFullOnMultiview));
                         break;
                     case InputKind.Ndi when !string.IsNullOrWhiteSpace(input.PathOrAddress):
                         Commands.TryEnqueue(new ConnectNdiCommand(
                             input.Id,
                             input.PathOrAddress,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)));
+                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+                            input.BandwidthSave,
+                            input.KeepFullOnMultiview));
                         break;
                     case InputKind.Uvc when !string.IsNullOrWhiteSpace(input.PathOrAddress):
                         Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress));

--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -17,6 +17,7 @@ internal sealed record PushUnitStateCommand(ulong UnitId, UnitState State) : Mix
 internal sealed record DefineSceneCommand(SceneEntry Scene, uint Width, uint Height) : MixerCommand;
 internal sealed record DestroySceneCommand(ulong GpuId) : MixerCommand;
 internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames) : MixerCommand;
+internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames) : MixerCommand;
 internal sealed record LoadStillCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartVideoCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartUvcCommand(ulong SourceId, string SymbolicLink) : MixerCommand;
@@ -74,10 +75,8 @@ internal sealed class CommandQueue : IAsyncDisposable
             output.SourceId,
             output.UnitId,
             output.UseGpu ? 1u : 0u);
-        if (output.Transport == OutputTransport.Omt)
+        if (code != 0)
             MixerNative.ThrowIfFailed(code, "Add output");
-        else if (code != 0)
-            throw new InvalidOperationException(MixerNative.LastErrorText());
     }
 
     public static UnitState BuildState(MixingUnitEntry unit, ulong program, ulong preview, float mix, uint transitionKind)
@@ -330,6 +329,14 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 connect.UseGpu ? 1u : 0u,
                                 Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
                             "OMT connect");
+                        break;
+                    case ConnectNdiCommand connect:
+                        MixerNative.ThrowIfFailed(
+                            MixerNative.ConnectNdi(
+                                connect.SourceId,
+                                connect.Address,
+                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
+                            "NDI connect");
                         break;
                     case LoadStillCommand still:
                         MixerNative.ThrowIfFailed(MixerNative.LoadStill(still.SourceId, still.Path), "Still load");

--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -16,8 +16,9 @@ internal sealed record PreviewSceneCommand(ulong UnitId, ulong SceneGpuId) : Mix
 internal sealed record PushUnitStateCommand(ulong UnitId, UnitState State) : MixerCommand;
 internal sealed record DefineSceneCommand(SceneEntry Scene, uint Width, uint Height) : MixerCommand;
 internal sealed record DestroySceneCommand(ulong GpuId) : MixerCommand;
-internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames) : MixerCommand;
-internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames) : MixerCommand;
+internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
+internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
+internal sealed record LiveSaveCommand(ulong SourceId, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
 internal sealed record LoadStillCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartVideoCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartUvcCommand(ulong SourceId, string SymbolicLink) : MixerCommand;
@@ -329,6 +330,12 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 connect.UseGpu ? 1u : 0u,
                                 Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
                             "OMT connect");
+                        MixerNative.ThrowIfFailed(
+                            MixerNative.SetLiveSave(
+                                connect.SourceId,
+                                (uint)connect.SaveMode,
+                                connect.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
+                            "OMT bandwidth save");
                         break;
                     case ConnectNdiCommand connect:
                         MixerNative.ThrowIfFailed(
@@ -337,6 +344,20 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 connect.Address,
                                 Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
                             "NDI connect");
+                        MixerNative.ThrowIfFailed(
+                            MixerNative.SetLiveSave(
+                                connect.SourceId,
+                                (uint)connect.SaveMode,
+                                connect.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
+                            "NDI bandwidth save");
+                        break;
+                    case LiveSaveCommand save:
+                        MixerNative.ThrowIfFailed(
+                            MixerNative.SetLiveSave(
+                                save.SourceId,
+                                (uint)save.SaveMode,
+                                save.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
+                            "Bandwidth save");
                         break;
                     case LoadStillCommand still:
                         MixerNative.ThrowIfFailed(MixerNative.LoadStill(still.SourceId, still.Path), "Still load");

--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -16,9 +16,9 @@ internal sealed record PreviewSceneCommand(ulong UnitId, ulong SceneGpuId) : Mix
 internal sealed record PushUnitStateCommand(ulong UnitId, UnitState State) : MixerCommand;
 internal sealed record DefineSceneCommand(SceneEntry Scene, uint Width, uint Height) : MixerCommand;
 internal sealed record DestroySceneCommand(ulong GpuId) : MixerCommand;
-internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
-internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
-internal sealed record LiveSaveCommand(ulong SourceId, BandwidthSave SaveMode, bool KeepFullOnMultiview) : MixerCommand;
+internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview, OmtQuality Quality) : MixerCommand;
+internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames) : MixerCommand;
+internal sealed record LiveSaveCommand(ulong SourceId, BandwidthSave SaveMode, bool KeepFullOnMultiview, OmtQuality? OmtQuality = null) : MixerCommand;
 internal sealed record LoadStillCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartVideoCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartUvcCommand(ulong SourceId, string SymbolicLink) : MixerCommand;
@@ -328,7 +328,8 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 connect.SourceId,
                                 connect.Address,
                                 connect.UseGpu ? 1u : 0u,
-                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
+                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
+                                (uint)connect.Quality),
                             "OMT connect");
                         MixerNative.ThrowIfFailed(
                             MixerNative.SetLiveSave(
@@ -344,12 +345,6 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 connect.Address,
                                 Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
                             "NDI connect");
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.SetLiveSave(
-                                connect.SourceId,
-                                (uint)connect.SaveMode,
-                                connect.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
-                            "NDI bandwidth save");
                         break;
                     case LiveSaveCommand save:
                         MixerNative.ThrowIfFailed(
@@ -358,6 +353,12 @@ internal sealed class CommandQueue : IAsyncDisposable
                                 (uint)save.SaveMode,
                                 save.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
                             "Bandwidth save");
+                        if (save.OmtQuality is { } quality)
+                        {
+                            MixerNative.ThrowIfFailed(
+                                MixerNative.SetOmtQuality(save.SourceId, (uint)quality),
+                                "OMT quality");
+                        }
                         break;
                     case LoadStillCommand still:
                         MixerNative.ThrowIfFailed(MixerNative.LoadStill(still.SourceId, still.Path), "Still load");

--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -17,7 +17,7 @@ internal sealed record PushUnitStateCommand(ulong UnitId, UnitState State) : Mix
 internal sealed record DefineSceneCommand(SceneEntry Scene, uint Width, uint Height) : MixerCommand;
 internal sealed record DestroySceneCommand(ulong GpuId) : MixerCommand;
 internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool UseGpu, uint FrameBufferFrames, BandwidthSave SaveMode, bool KeepFullOnMultiview, OmtQuality Quality) : MixerCommand;
-internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames) : MixerCommand;
+internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames, NdiBandwidth Bandwidth) : MixerCommand;
 internal sealed record LiveSaveCommand(ulong SourceId, BandwidthSave SaveMode, bool KeepFullOnMultiview, OmtQuality? OmtQuality = null) : MixerCommand;
 internal sealed record LoadStillCommand(ulong SourceId, string Path) : MixerCommand;
 internal sealed record StartVideoCommand(ulong SourceId, string Path) : MixerCommand;
@@ -343,7 +343,8 @@ internal sealed class CommandQueue : IAsyncDisposable
                             MixerNative.ConnectNdi(
                                 connect.SourceId,
                                 connect.Address,
-                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u)),
+                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
+                                connect.Bandwidth == NdiBandwidth.Lowest ? 1u : 0u),
                             "NDI connect");
                         break;
                     case LiveSaveCommand save:

--- a/host/Dialogs/AddInputWindow.xaml
+++ b/host/Dialogs/AddInputWindow.xaml
@@ -117,9 +117,14 @@
                         <ComboBoxItem Content="6" Tag="6"/>
                         <ComboBoxItem Content="8" Tag="8"/>
                     </ComboBox>
+                    <TextBlock Text="Bandwidth" Margin="0,4,0,4"/>
+                    <ComboBox x:Name="NdiBandwidthBox" Width="220" HorizontalAlignment="Left" Margin="0,0,0,8">
+                        <ComboBoxItem Content="Highest" Tag="0" IsSelected="True"/>
+                        <ComboBoxItem Content="Lowest" Tag="1"/>
+                    </ComboBox>
                     <TextBlock x:Name="NdiStatus" Margin="0,0,0,8" TextWrapping="Wrap" Foreground="#C88"/>
                     <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
-                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source."/>
+                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source. Bandwidth is set when connecting. Lowest is the public SDK preview stream."/>
                 </StackPanel>
                 <StackPanel x:Name="UvcPanel" Visibility="Collapsed">
                     <TextBlock Text="Select a UVC / Media Foundation capture device." Margin="0,0,0,8"/>

--- a/host/Dialogs/AddInputWindow.xaml
+++ b/host/Dialogs/AddInputWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="Eiviz.Host.Dialogs.AddInputWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Input Select" Height="560" Width="820"
+        Title="Input Select" Height="640" Width="820"
         WindowStartupLocation="CenterOwner"
         Background="#2B2B2B" Foreground="#EEEEEE">
     <Grid>
@@ -68,7 +68,7 @@
                     <TextBlock Text="OMT source address" Margin="0,0,0,8"/>
                     <TextBox x:Name="OmtAddress"/>
                     <Button Content="Refresh discovery" Margin="0,12,0,8" HorizontalAlignment="Left" Click="RefreshOmt_Click"/>
-                    <ListBox x:Name="OmtList" Height="180" Background="#333" Foreground="#EEE"
+                    <ListBox x:Name="OmtList" Height="132" Background="#333" Foreground="#EEE"
                              SelectionChanged="OmtList_SelectionChanged"/>
                     <TextBlock Text="Decode path" Margin="0,12,0,4"/>
                     <ComboBox x:Name="OmtPathBox" Width="220" HorizontalAlignment="Left" Margin="0,0,0,8">
@@ -84,14 +84,22 @@
                         <ComboBoxItem Content="6" Tag="6"/>
                         <ComboBoxItem Content="8" Tag="8"/>
                     </ComboBox>
+                    <TextBlock Text="Save bandwidth when" Margin="0,4,0,4"/>
+                    <ComboBox x:Name="OmtSaveBox" Width="280" HorizontalAlignment="Left" Margin="0,0,0,8">
+                        <ComboBoxItem Content="Always (low quality)" Tag="0"/>
+                        <ComboBoxItem Content="Not on Program (any MU)" Tag="1"/>
+                        <ComboBoxItem Content="Not on Preview/Program (any MU)" Tag="2" IsSelected="True"/>
+                        <ComboBoxItem Content="None (always full)" Tag="3"/>
+                    </ComboBox>
+                    <CheckBox x:Name="OmtMvBox" Content="Keep full quality on Multiview" Foreground="#EEE" Margin="0,0,0,8"/>
                     <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
-                               Text="GPU decode keeps VMX frames on the GPU. CPU decode copies into system memory. Frame buffer (1–8) absorbs jitter on this source."/>
+                               Text="GPU decode keeps VMX frames on the GPU. CPU decode copies into system memory. Frame buffer (1–8) absorbs jitter on this source. Unused OMT sources can request preview (1/8) and Low quality."/>
                 </StackPanel>
                 <StackPanel x:Name="NdiPanel" Visibility="Collapsed">
                     <TextBlock Text="NDI® source" Margin="0,0,0,8"/>
                     <TextBox x:Name="NdiAddress"/>
                     <Button Content="Refresh discovery" Margin="0,12,0,8" HorizontalAlignment="Left" Click="RefreshNdi_Click"/>
-                    <ListBox x:Name="NdiList" Height="180" Background="#333" Foreground="#EEE"
+                    <ListBox x:Name="NdiList" Height="132" Background="#333" Foreground="#EEE"
                              SelectionChanged="NdiList_SelectionChanged"/>
                     <TextBlock Text="Frame buffer (frames)" Margin="0,12,0,0"/>
                     <ComboBox x:Name="NdiBufferBox" Width="220" HorizontalAlignment="Left" Margin="0,4,0,8">
@@ -102,8 +110,17 @@
                         <ComboBoxItem Content="6" Tag="6"/>
                         <ComboBoxItem Content="8" Tag="8"/>
                     </ComboBox>
+                    <TextBlock Text="Save bandwidth when" Margin="0,4,0,4"/>
+                    <ComboBox x:Name="NdiSaveBox" Width="280" HorizontalAlignment="Left" Margin="0,0,0,8">
+                        <ComboBoxItem Content="Always (low quality)" Tag="0"/>
+                        <ComboBoxItem Content="Not on Program (any MU)" Tag="1"/>
+                        <ComboBoxItem Content="Not on Preview/Program (any MU)" Tag="2" IsSelected="True"/>
+                        <ComboBoxItem Content="None (always full)" Tag="3"/>
+                    </ComboBox>
+                    <CheckBox x:Name="NdiMvBox" Content="Keep full quality on Multiview" Foreground="#EEE" Margin="0,0,0,8"/>
+                    <TextBlock x:Name="NdiStatus" Margin="0,0,0,8" TextWrapping="Wrap" Foreground="#C88"/>
                     <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
-                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source."/>
+                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source. Unused NDI sources drop to NDI Lowest bandwidth."/>
                 </StackPanel>
                 <StackPanel x:Name="UvcPanel" Visibility="Collapsed">
                     <TextBlock Text="Select a UVC / Media Foundation capture device." Margin="0,0,0,8"/>

--- a/host/Dialogs/AddInputWindow.xaml
+++ b/host/Dialogs/AddInputWindow.xaml
@@ -88,8 +88,22 @@
                                Text="GPU decode keeps VMX frames on the GPU. CPU decode copies into system memory. Frame buffer (1–8) absorbs jitter on this source."/>
                 </StackPanel>
                 <StackPanel x:Name="NdiPanel" Visibility="Collapsed">
-                    <TextBlock TextWrapping="Wrap"
-                               Text="NDI receive is not linked in this build. Use OMT for AV-over-IP until the NDI SDK is added. This dialog will not create a fake source."/>
+                    <TextBlock Text="NDI® source" Margin="0,0,0,8"/>
+                    <TextBox x:Name="NdiAddress"/>
+                    <Button Content="Refresh discovery" Margin="0,12,0,8" HorizontalAlignment="Left" Click="RefreshNdi_Click"/>
+                    <ListBox x:Name="NdiList" Height="180" Background="#333" Foreground="#EEE"
+                             SelectionChanged="NdiList_SelectionChanged"/>
+                    <TextBlock Text="Frame buffer (frames)" Margin="0,12,0,0"/>
+                    <ComboBox x:Name="NdiBufferBox" Width="220" HorizontalAlignment="Left" Margin="0,4,0,8">
+                        <ComboBoxItem Content="1" Tag="1" IsSelected="True"/>
+                        <ComboBoxItem Content="2" Tag="2"/>
+                        <ComboBoxItem Content="3" Tag="3"/>
+                        <ComboBoxItem Content="4" Tag="4"/>
+                        <ComboBoxItem Content="6" Tag="6"/>
+                        <ComboBoxItem Content="8" Tag="8"/>
+                    </ComboBox>
+                    <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
+                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source."/>
                 </StackPanel>
                 <StackPanel x:Name="UvcPanel" Visibility="Collapsed">
                     <TextBlock Text="Select a UVC / Media Foundation capture device." Margin="0,0,0,8"/>

--- a/host/Dialogs/AddInputWindow.xaml
+++ b/host/Dialogs/AddInputWindow.xaml
@@ -75,6 +75,13 @@
                         <ComboBoxItem Content="GPU decode" Tag="gpu" IsSelected="True"/>
                         <ComboBoxItem Content="CPU decode" Tag="cpu"/>
                     </ComboBox>
+                    <TextBlock Text="Quality" Margin="0,0,0,4"/>
+                    <ComboBox x:Name="OmtQualityBox" Width="220" HorizontalAlignment="Left" Margin="0,0,0,8">
+                        <ComboBoxItem Content="Default" Tag="0" IsSelected="True"/>
+                        <ComboBoxItem Content="Low" Tag="1"/>
+                        <ComboBoxItem Content="Medium" Tag="50"/>
+                        <ComboBoxItem Content="High" Tag="100"/>
+                    </ComboBox>
                     <TextBlock Text="Frame buffer (frames)"/>
                     <ComboBox x:Name="OmtBufferBox" Width="220" HorizontalAlignment="Left" Margin="0,4,0,8">
                         <ComboBoxItem Content="1" Tag="1" IsSelected="True"/>
@@ -93,7 +100,7 @@
                     </ComboBox>
                     <CheckBox x:Name="OmtMvBox" Content="Keep full quality on Multiview" Foreground="#EEE" Margin="0,0,0,8"/>
                     <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
-                               Text="GPU decode keeps VMX frames on the GPU. CPU decode copies into system memory. Frame buffer (1–8) absorbs jitter on this source. Unused OMT sources can request preview (1/8) and Low quality."/>
+                               Text="GPU decode keeps VMX frames on the GPU. CPU decode copies into system memory. Frame buffer (1–8) absorbs jitter on this source. Quality is requested from the sender. Unused sources stay connected and also request Preview (1/8 decode)."/>
                 </StackPanel>
                 <StackPanel x:Name="NdiPanel" Visibility="Collapsed">
                     <TextBlock Text="NDI® source" Margin="0,0,0,8"/>
@@ -110,17 +117,9 @@
                         <ComboBoxItem Content="6" Tag="6"/>
                         <ComboBoxItem Content="8" Tag="8"/>
                     </ComboBox>
-                    <TextBlock Text="Save bandwidth when" Margin="0,4,0,4"/>
-                    <ComboBox x:Name="NdiSaveBox" Width="280" HorizontalAlignment="Left" Margin="0,0,0,8">
-                        <ComboBoxItem Content="Always (low quality)" Tag="0"/>
-                        <ComboBoxItem Content="Not on Program (any MU)" Tag="1"/>
-                        <ComboBoxItem Content="Not on Preview/Program (any MU)" Tag="2" IsSelected="True"/>
-                        <ComboBoxItem Content="None (always full)" Tag="3"/>
-                    </ComboBox>
-                    <CheckBox x:Name="NdiMvBox" Content="Keep full quality on Multiview" Foreground="#EEE" Margin="0,0,0,8"/>
                     <TextBlock x:Name="NdiStatus" Margin="0,0,0,8" TextWrapping="Wrap" Foreground="#C88"/>
                     <TextBlock TextWrapping="Wrap" Foreground="#AAAAAA"
-                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source. Unused NDI sources drop to NDI Lowest bandwidth."/>
+                               Text="NDI is received on the CPU and uploaded for compose. Frame buffer (1–8) absorbs jitter on this source."/>
                 </StackPanel>
                 <StackPanel x:Name="UvcPanel" Visibility="Collapsed">
                     <TextBlock Text="Select a UVC / Media Foundation capture device." Margin="0,0,0,8"/>

--- a/host/Dialogs/AddInputWindow.xaml.cs
+++ b/host/Dialogs/AddInputWindow.xaml.cs
@@ -49,6 +49,7 @@ public partial class AddInputWindow : Window
     public uint ResultFrameBufferFrames { get; private set; } = 1;
     public BandwidthSave ResultSaveMode { get; private set; } = BandwidthSave.NotOnPreviewOrProgram;
     public bool ResultKeepFullOnMultiview { get; private set; }
+    public OmtQuality ResultOmtQuality { get; private set; } = OmtQuality.Default;
 
     public void Load(InputEntry input)
     {
@@ -69,12 +70,11 @@ public partial class AddInputWindow : Window
         OmtAddress.Text = input.Kind == InputKind.Omt ? input.PathOrAddress ?? "" : "";
         NdiAddress.Text = input.Kind == InputKind.Ndi ? input.PathOrAddress ?? "" : "";
         SelectTag(OmtPathBox, input.UseGpu ? "gpu" : "cpu");
+        SelectTag(OmtQualityBox, ((int)input.OmtQuality).ToString());
         SelectTag(OmtBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
         SelectTag(NdiBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
         SelectTag(OmtSaveBox, ((int)input.BandwidthSave).ToString());
-        SelectTag(NdiSaveBox, ((int)input.BandwidthSave).ToString());
         OmtMvBox.IsChecked = input.KeepFullOnMultiview;
-        NdiMvBox.IsChecked = input.KeepFullOnMultiview;
         if (input.Kind == InputKind.Uvc && !string.IsNullOrWhiteSpace(input.PathOrAddress))
         {
             foreach (var item in UvcList.Items)
@@ -254,6 +254,7 @@ public partial class AddInputWindow : Window
                     ResultFrameBufferFrames = Math.Clamp(frames, 1u, 8u);
                 ResultSaveMode = ReadSaveMode(OmtSaveBox);
                 ResultKeepFullOnMultiview = OmtMvBox.IsChecked == true;
+                ResultOmtQuality = ReadOmtQuality(OmtQualityBox);
                 break;
             case InputKind.Ndi:
                 if (string.IsNullOrWhiteSpace(NdiAddress.Text))
@@ -265,8 +266,6 @@ public partial class AddInputWindow : Window
                 if (NdiBufferBox.SelectedItem is ComboBoxItem ndiBuffer && ndiBuffer.Tag is string ndiTag
                     && uint.TryParse(ndiTag, out var ndiFrames))
                     ResultFrameBufferFrames = Math.Clamp(ndiFrames, 1u, 8u);
-                ResultSaveMode = ReadSaveMode(NdiSaveBox);
-                ResultKeepFullOnMultiview = NdiMvBox.IsChecked == true;
                 break;
             case InputKind.Uvc:
                 if (UvcList.SelectedItem is not CameraItem camera || string.IsNullOrEmpty(camera.Link))
@@ -280,6 +279,21 @@ public partial class AddInputWindow : Window
         if (!string.IsNullOrWhiteSpace(NameBox.Text))
             ResultName = NameBox.Text.Trim();
         DialogResult = true;
+    }
+
+    private static OmtQuality ReadOmtQuality(ComboBox box)
+    {
+        if (box.SelectedItem is ComboBoxItem item && item.Tag is string tag && uint.TryParse(tag, out var value))
+        {
+            return value switch
+            {
+                1 => OmtQuality.Low,
+                50 => OmtQuality.Medium,
+                100 => OmtQuality.High,
+                _ => OmtQuality.Default
+            };
+        }
+        return OmtQuality.Default;
     }
 
     private static BandwidthSave ReadSaveMode(ComboBox box)

--- a/host/Dialogs/AddInputWindow.xaml.cs
+++ b/host/Dialogs/AddInputWindow.xaml.cs
@@ -50,6 +50,7 @@ public partial class AddInputWindow : Window
     public BandwidthSave ResultSaveMode { get; private set; } = BandwidthSave.NotOnPreviewOrProgram;
     public bool ResultKeepFullOnMultiview { get; private set; }
     public OmtQuality ResultOmtQuality { get; private set; } = OmtQuality.Default;
+    public NdiBandwidth ResultNdiBandwidth { get; private set; } = NdiBandwidth.Highest;
 
     public void Load(InputEntry input)
     {
@@ -73,6 +74,7 @@ public partial class AddInputWindow : Window
         SelectTag(OmtQualityBox, ((int)input.OmtQuality).ToString());
         SelectTag(OmtBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
         SelectTag(NdiBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
+        SelectTag(NdiBandwidthBox, ((int)input.NdiBandwidth).ToString());
         SelectTag(OmtSaveBox, ((int)input.BandwidthSave).ToString());
         OmtMvBox.IsChecked = input.KeepFullOnMultiview;
         if (input.Kind == InputKind.Uvc && !string.IsNullOrWhiteSpace(input.PathOrAddress))
@@ -266,6 +268,7 @@ public partial class AddInputWindow : Window
                 if (NdiBufferBox.SelectedItem is ComboBoxItem ndiBuffer && ndiBuffer.Tag is string ndiTag
                     && uint.TryParse(ndiTag, out var ndiFrames))
                     ResultFrameBufferFrames = Math.Clamp(ndiFrames, 1u, 8u);
+                ResultNdiBandwidth = ReadNdiBandwidth(NdiBandwidthBox);
                 break;
             case InputKind.Uvc:
                 if (UvcList.SelectedItem is not CameraItem camera || string.IsNullOrEmpty(camera.Link))
@@ -279,6 +282,13 @@ public partial class AddInputWindow : Window
         if (!string.IsNullOrWhiteSpace(NameBox.Text))
             ResultName = NameBox.Text.Trim();
         DialogResult = true;
+    }
+
+    private static NdiBandwidth ReadNdiBandwidth(ComboBox box)
+    {
+        if (box.SelectedItem is ComboBoxItem item && item.Tag is string tag && uint.TryParse(tag, out var value))
+            return value == 1 ? NdiBandwidth.Lowest : NdiBandwidth.Highest;
+        return NdiBandwidth.Highest;
     }
 
     private static OmtQuality ReadOmtQuality(ComboBox box)

--- a/host/Dialogs/AddInputWindow.xaml.cs
+++ b/host/Dialogs/AddInputWindow.xaml.cs
@@ -47,6 +47,8 @@ public partial class AddInputWindow : Window
     public bool Scroll { get; private set; }
     public bool ResultUseGpu { get; private set; } = true;
     public uint ResultFrameBufferFrames { get; private set; } = 1;
+    public BandwidthSave ResultSaveMode { get; private set; } = BandwidthSave.NotOnPreviewOrProgram;
+    public bool ResultKeepFullOnMultiview { get; private set; }
 
     public void Load(InputEntry input)
     {
@@ -69,6 +71,10 @@ public partial class AddInputWindow : Window
         SelectTag(OmtPathBox, input.UseGpu ? "gpu" : "cpu");
         SelectTag(OmtBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
         SelectTag(NdiBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
+        SelectTag(OmtSaveBox, ((int)input.BandwidthSave).ToString());
+        SelectTag(NdiSaveBox, ((int)input.BandwidthSave).ToString());
+        OmtMvBox.IsChecked = input.KeepFullOnMultiview;
+        NdiMvBox.IsChecked = input.KeepFullOnMultiview;
         if (input.Kind == InputKind.Uvc && !string.IsNullOrWhiteSpace(input.PathOrAddress))
         {
             foreach (var item in UvcList.Items)
@@ -173,6 +179,9 @@ public partial class AddInputWindow : Window
         NdiList.ItemsSource = string.IsNullOrWhiteSpace(text)
             ? Array.Empty<string>()
             : text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (NdiStatus is null)
+            return;
+        NdiStatus.Text = NdiList.Items.Count == 0 ? MixerNative.LastErrorText() : "";
     }
 
     private void NdiList_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -243,6 +252,8 @@ public partial class AddInputWindow : Window
                 if (OmtBufferBox.SelectedItem is ComboBoxItem buffer && buffer.Tag is string tag
                     && uint.TryParse(tag, out var frames))
                     ResultFrameBufferFrames = Math.Clamp(frames, 1u, 8u);
+                ResultSaveMode = ReadSaveMode(OmtSaveBox);
+                ResultKeepFullOnMultiview = OmtMvBox.IsChecked == true;
                 break;
             case InputKind.Ndi:
                 if (string.IsNullOrWhiteSpace(NdiAddress.Text))
@@ -254,6 +265,8 @@ public partial class AddInputWindow : Window
                 if (NdiBufferBox.SelectedItem is ComboBoxItem ndiBuffer && ndiBuffer.Tag is string ndiTag
                     && uint.TryParse(ndiTag, out var ndiFrames))
                     ResultFrameBufferFrames = Math.Clamp(ndiFrames, 1u, 8u);
+                ResultSaveMode = ReadSaveMode(NdiSaveBox);
+                ResultKeepFullOnMultiview = NdiMvBox.IsChecked == true;
                 break;
             case InputKind.Uvc:
                 if (UvcList.SelectedItem is not CameraItem camera || string.IsNullOrEmpty(camera.Link))
@@ -267,6 +280,13 @@ public partial class AddInputWindow : Window
         if (!string.IsNullOrWhiteSpace(NameBox.Text))
             ResultName = NameBox.Text.Trim();
         DialogResult = true;
+    }
+
+    private static BandwidthSave ReadSaveMode(ComboBox box)
+    {
+        if (box.SelectedItem is ComboBoxItem item && item.Tag is string tag && uint.TryParse(tag, out var mode))
+            return (BandwidthSave)Math.Clamp(mode, 0u, 3u);
+        return BandwidthSave.NotOnPreviewOrProgram;
     }
 
     private static void SelectTag(ComboBox box, string tag)

--- a/host/Dialogs/AddInputWindow.xaml.cs
+++ b/host/Dialogs/AddInputWindow.xaml.cs
@@ -34,6 +34,7 @@ public partial class AddInputWindow : Window
         VideoRecent.ItemsSource = VideoHistory.ToArray();
         Highlight();
         RefreshOmt();
+        RefreshNdi();
         RefreshUvc();
     }
 
@@ -64,8 +65,10 @@ public partial class AddInputWindow : Window
         StillPath.Text = input.Kind == InputKind.Still ? input.PathOrAddress ?? "" : "";
         VideoPath.Text = input.Kind == InputKind.Video ? input.PathOrAddress ?? "" : "";
         OmtAddress.Text = input.Kind == InputKind.Omt ? input.PathOrAddress ?? "" : "";
+        NdiAddress.Text = input.Kind == InputKind.Ndi ? input.PathOrAddress ?? "" : "";
         SelectTag(OmtPathBox, input.UseGpu ? "gpu" : "cpu");
         SelectTag(OmtBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
+        SelectTag(NdiBufferBox, Math.Clamp(input.FrameBufferFrames == 0 ? 1 : input.FrameBufferFrames, 1u, 8u).ToString());
         if (input.Kind == InputKind.Uvc && !string.IsNullOrWhiteSpace(input.PathOrAddress))
         {
             foreach (var item in UvcList.Items)
@@ -102,7 +105,6 @@ public partial class AddInputWindow : Window
         OmtPanel.Visibility = VisibleIf(InputKind.Omt);
         NdiPanel.Visibility = VisibleIf(InputKind.Ndi);
         UvcPanel.Visibility = VisibleIf(InputKind.Uvc);
-        OkButton.IsEnabled = _kind != InputKind.Ndi;
         foreach (Button button in CategoryPanel.Children)
             button.Background = Equals(button.Tag, _kind)
                 ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x2E, 0x6B, 0x3C))
@@ -161,6 +163,22 @@ public partial class AddInputWindow : Window
         OmtList.ItemsSource = string.IsNullOrWhiteSpace(text)
             ? Array.Empty<string>()
             : text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private void RefreshNdi_Click(object sender, RoutedEventArgs e) => RefreshNdi();
+
+    private void RefreshNdi()
+    {
+        var text = MixerNative.DiscoverNdiText();
+        NdiList.ItemsSource = string.IsNullOrWhiteSpace(text)
+            ? Array.Empty<string>()
+            : text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private void NdiList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (NdiList.SelectedItem is string address)
+            NdiAddress.Text = address;
     }
 
     private void OmtList_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -225,6 +243,17 @@ public partial class AddInputWindow : Window
                 if (OmtBufferBox.SelectedItem is ComboBoxItem buffer && buffer.Tag is string tag
                     && uint.TryParse(tag, out var frames))
                     ResultFrameBufferFrames = Math.Clamp(frames, 1u, 8u);
+                break;
+            case InputKind.Ndi:
+                if (string.IsNullOrWhiteSpace(NdiAddress.Text))
+                    return;
+                ResultPath = NdiAddress.Text.Trim();
+                ResultName = ResultPath;
+                ResultUseGpu = false;
+                ResultFrameBufferFrames = 1;
+                if (NdiBufferBox.SelectedItem is ComboBoxItem ndiBuffer && ndiBuffer.Tag is string ndiTag
+                    && uint.TryParse(ndiTag, out var ndiFrames))
+                    ResultFrameBufferFrames = Math.Clamp(ndiFrames, 1u, 8u);
                 break;
             case InputKind.Uvc:
                 if (UvcList.SelectedItem is not CameraItem camera || string.IsNullOrEmpty(camera.Link))

--- a/host/Dialogs/ResourceMonitorWindow.xaml.cs
+++ b/host/Dialogs/ResourceMonitorWindow.xaml.cs
@@ -60,7 +60,7 @@ public partial class ResourceMonitorWindow : Window
             usages.TryGetValue(input.Id, out var usage);
             var ram = usage.RamBytes;
             var vram = usage.VramBytes;
-            var cpu = input.Kind is InputKind.Omt or InputKind.Uvc or InputKind.Video ? "live" : "—";
+            var cpu = input.Kind is InputKind.Omt or InputKind.Ndi or InputKind.Uvc or InputKind.Video ? "live" : "—";
             var gpu = vram == 0 ? "—" : $"{vram / (double)totalVram * gpuLoad:0}%";
             rows.Add(new Row(
                 input.Name,

--- a/host/Dialogs/SettingsWindow.xaml
+++ b/host/Dialogs/SettingsWindow.xaml
@@ -118,7 +118,7 @@
             <StackPanel x:Name="AboutPanel" Margin="20" Visibility="Collapsed">
                 <TextBlock Text="eiviz" FontSize="18" FontWeight="Bold"/>
                 <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
-                           Text="WPF host + Rust wgpu DX12 mixer. OMT/VMX use openmediatransport-rs and vmx-rs. NDI® uses grafton-ndi and the NDI SDK (https://ndi.video/)."/>
+                           Text="Windows host and DirectX 12 mixer."/>
             </StackPanel>
         </DockPanel>
     </Grid>

--- a/host/Dialogs/SettingsWindow.xaml
+++ b/host/Dialogs/SettingsWindow.xaml
@@ -70,7 +70,7 @@
                     <TextBlock Text="Outputs" FontWeight="Bold" VerticalAlignment="Center"/>
                 </DockPanel>
                 <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Foreground="#AAAAAA" Margin="0,0,0,8"
-                           Text="OMT is sent from the mixer. NDI and DeckLink are listed here but fail immediately until those SDKs are linked. For OMT, Encode path chooses GPU encode (frame stays on the GPU) or CPU encode (UYVY pack and readback)."/>
+                           Text="OMT and NDI® are sent from the mixer. DeckLink is listed here but fails immediately until that SDK is linked. For OMT, Encode path chooses GPU encode (frame stays on the GPU) or CPU encode (UYVY pack and readback). NDI always uses CPU encode."/>
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel x:Name="OutputRows"/>
                 </ScrollViewer>
@@ -118,7 +118,7 @@
             <StackPanel x:Name="AboutPanel" Margin="20" Visibility="Collapsed">
                 <TextBlock Text="eiviz" FontSize="18" FontWeight="Bold"/>
                 <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
-                           Text="WPF host + Rust wgpu DX12 mixer. OMT/VMX use openmediatransport-rs and vmx-rs."/>
+                           Text="WPF host + Rust wgpu DX12 mixer. OMT/VMX use openmediatransport-rs and vmx-rs. NDI® uses grafton-ndi and the NDI SDK (https://ndi.video/)."/>
             </StackPanel>
         </DockPanel>
     </Grid>

--- a/host/Dialogs/SettingsWindow.xaml.cs
+++ b/host/Dialogs/SettingsWindow.xaml.cs
@@ -366,7 +366,11 @@ public partial class SettingsWindow : Window
             transport.SelectionChanged += (_, _) =>
             {
                 if (transport.SelectedItem is ComboBoxItem item && item.Tag is OutputTransport value)
+                {
                     output.Transport = value;
+                    if (value != OutputTransport.Omt)
+                        output.UseGpu = false;
+                }
                 RebuildOutputs();
             };
 

--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -18,9 +18,17 @@
   <Target Name="BuildMixer" BeforeTargets="Build">
     <Exec Command="cargo build --release" WorkingDirectory="$(MixerProject)" />
     <Copy SourceFiles="$(MixerLibrary)" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="$(MixerProject)\target\release\Processing.NDI.Lib.x64.dll" DestinationFolder="$(OutDir)" Condition="Exists('$(MixerProject)\target\release\Processing.NDI.Lib.x64.dll')" />
+    <Copy SourceFiles="$(NDI_SDK_DIR)\Bin\x64\Processing.NDI.Lib.x64.dll" DestinationFolder="$(OutDir)" Condition="!Exists('$(OutDir)Processing.NDI.Lib.x64.dll') and '$(NDI_SDK_DIR)' != '' and Exists('$(NDI_SDK_DIR)\Bin\x64\Processing.NDI.Lib.x64.dll')" />
+    <Copy SourceFiles="C:\Program Files\NDI\NDI 6 SDK\Bin\x64\Processing.NDI.Lib.x64.dll" DestinationFolder="$(OutDir)" Condition="!Exists('$(OutDir)Processing.NDI.Lib.x64.dll') and Exists('C:\Program Files\NDI\NDI 6 SDK\Bin\x64\Processing.NDI.Lib.x64.dll')" />
+    <Error Text="NDI runtime DLL not found. Install the NDI SDK 6 and set NDI_SDK_DIR if it is not in the default location." Condition="!Exists('$(OutDir)Processing.NDI.Lib.x64.dll')" />
   </Target>
 
   <Target Name="PublishMixer" AfterTargets="Publish">
     <Copy SourceFiles="$(MixerLibrary)" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="$(MixerProject)\target\release\Processing.NDI.Lib.x64.dll" DestinationFolder="$(PublishDir)" Condition="Exists('$(MixerProject)\target\release\Processing.NDI.Lib.x64.dll')" />
+    <Copy SourceFiles="$(NDI_SDK_DIR)\Bin\x64\Processing.NDI.Lib.x64.dll" DestinationFolder="$(PublishDir)" Condition="!Exists('$(PublishDir)Processing.NDI.Lib.x64.dll') and '$(NDI_SDK_DIR)' != '' and Exists('$(NDI_SDK_DIR)\Bin\x64\Processing.NDI.Lib.x64.dll')" />
+    <Copy SourceFiles="C:\Program Files\NDI\NDI 6 SDK\Bin\x64\Processing.NDI.Lib.x64.dll" DestinationFolder="$(PublishDir)" Condition="!Exists('$(PublishDir)Processing.NDI.Lib.x64.dll') and Exists('C:\Program Files\NDI\NDI 6 SDK\Bin\x64\Processing.NDI.Lib.x64.dll')" />
+    <Error Text="NDI runtime DLL not found. Install the NDI SDK 6 and set NDI_SDK_DIR if it is not in the default location." Condition="!Exists('$(PublishDir)Processing.NDI.Lib.x64.dll')" />
   </Target>
 </Project>

--- a/host/Interop/MixerNative.cs
+++ b/host/Interop/MixerNative.cs
@@ -174,7 +174,10 @@ internal static partial class MixerNative
     internal static unsafe partial int CopyVideoInfo(ulong id, MixerVideoInfo* info);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_omt_connect", StringMarshalling = StringMarshalling.Utf8)]
-    internal static partial int ConnectOmt(ulong id, string address, uint useGpu, uint frameBufferFrames);
+    internal static partial int ConnectOmt(ulong id, string address, uint useGpu, uint frameBufferFrames, uint quality);
+
+    [LibraryImport(LibraryName, EntryPoint = "mixer_omt_set_quality")]
+    internal static partial int SetOmtQuality(ulong id, uint quality);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_ndi_connect", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int ConnectNdi(ulong id, string address, uint frameBufferFrames);

--- a/host/Interop/MixerNative.cs
+++ b/host/Interop/MixerNative.cs
@@ -180,7 +180,7 @@ internal static partial class MixerNative
     internal static partial int SetOmtQuality(ulong id, uint quality);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_ndi_connect", StringMarshalling = StringMarshalling.Utf8)]
-    internal static partial int ConnectNdi(ulong id, string address, uint frameBufferFrames);
+    internal static partial int ConnectNdi(ulong id, string address, uint frameBufferFrames, uint lowBandwidth);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_set_live_save")]
     internal static partial int SetLiveSave(ulong id, uint mode, uint flags);

--- a/host/Interop/MixerNative.cs
+++ b/host/Interop/MixerNative.cs
@@ -171,6 +171,9 @@ internal static partial class MixerNative
     [LibraryImport(LibraryName, EntryPoint = "mixer_omt_connect", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int ConnectOmt(ulong id, string address, uint useGpu, uint frameBufferFrames);
 
+    [LibraryImport(LibraryName, EntryPoint = "mixer_ndi_connect", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int ConnectNdi(ulong id, string address, uint frameBufferFrames);
+
     [LibraryImport(LibraryName, EntryPoint = "mixer_define_scene")]
     internal static unsafe partial int DefineScene(ulong sceneId, uint width, uint height, uint count, OverlayDesc* layers);
 
@@ -191,6 +194,9 @@ internal static partial class MixerNative
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_omt_discover")]
     internal static unsafe partial int Discover(byte* buffer, nuint capacity);
+
+    [LibraryImport(LibraryName, EntryPoint = "mixer_ndi_discover")]
+    internal static unsafe partial int DiscoverNdi(byte* buffer, nuint capacity);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_copy_audio_peaks")]
     internal static unsafe partial int CopyAudioPeaks(AudioPeak* peaks, uint capacity);
@@ -231,6 +237,21 @@ internal static partial class MixerNative
             fixed (byte* ptr = buffer)
             {
                 var n = Discover(ptr, (nuint)buffer.Length);
+                if (n <= 0)
+                    return string.Empty;
+                return Encoding.UTF8.GetString(buffer, 0, n);
+            }
+        }
+    }
+
+    internal static string DiscoverNdiText()
+    {
+        var buffer = new byte[8192];
+        unsafe
+        {
+            fixed (byte* ptr = buffer)
+            {
+                var n = DiscoverNdi(ptr, (nuint)buffer.Length);
                 if (n <= 0)
                     return string.Empty;
                 return Encoding.UTF8.GetString(buffer, 0, n);

--- a/host/Interop/MixerNative.cs
+++ b/host/Interop/MixerNative.cs
@@ -34,6 +34,11 @@ internal static partial class MixerNative
     internal const uint SrcKindInput = 4;
     internal const uint GenSolid = 0;
     internal const uint GenBars = 1;
+    internal const uint SaveAlwaysLow = 0;
+    internal const uint SaveNotOnProgram = 1;
+    internal const uint SaveNotOnPreviewOrProgram = 2;
+    internal const uint SaveAlwaysFull = 3;
+    internal const uint SaveFlagMultiview = 1;
     internal const ulong MuSourceFlag = 0x8000_0000_0000_0000UL;
     internal const ulong MuBusPreview = 0x1000_0000_0000_0000UL;
     internal const ulong MuIdMask = 0x0FFF_FFFF_FFFF_FFFFUL;
@@ -173,6 +178,9 @@ internal static partial class MixerNative
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_ndi_connect", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int ConnectNdi(ulong id, string address, uint frameBufferFrames);
+
+    [LibraryImport(LibraryName, EntryPoint = "mixer_set_live_save")]
+    internal static partial int SetLiveSave(ulong id, uint mode, uint flags);
 
     [LibraryImport(LibraryName, EntryPoint = "mixer_define_scene")]
     internal static unsafe partial int DefineScene(ulong sceneId, uint width, uint height, uint count, OverlayDesc* layers);

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -629,7 +629,8 @@ public partial class MainWindow : Window
             && dialog.Kind is InputKind.Omt or InputKind.Ndi
             && input.PathOrAddress == dialog.ResultPath
             && input.UseGpu == (dialog.Kind == InputKind.Omt && dialog.ResultUseGpu)
-            && input.FrameBufferFrames == dialog.ResultFrameBufferFrames;
+            && input.FrameBufferFrames == dialog.ResultFrameBufferFrames
+            && (dialog.Kind != InputKind.Ndi || input.NdiBandwidth == dialog.ResultNdiBandwidth);
         if (replacing && !keepLive && !input.IsBuiltin && (!wasGenerator || !nowGenerator))
         {
             Commands.TryEnqueue(new DropSourceCommand(input.Id));
@@ -652,6 +653,7 @@ public partial class MainWindow : Window
         input.KeepFullOnMultiview = dialog.Kind == InputKind.Omt
             && dialog.ResultKeepFullOnMultiview;
         input.OmtQuality = dialog.Kind == InputKind.Omt ? dialog.ResultOmtQuality : OmtQuality.Default;
+        input.NdiBandwidth = dialog.Kind == InputKind.Ndi ? dialog.ResultNdiBandwidth : NdiBandwidth.Highest;
         if (keepLive)
         {
             if (dialog.Kind == InputKind.Omt)
@@ -696,7 +698,8 @@ public partial class MainWindow : Window
                 Commands.TryEnqueue(new ConnectNdiCommand(
                     input.Id,
                     dialog.ResultPath!,
-                    dialog.ResultFrameBufferFrames));
+                    dialog.ResultFrameBufferFrames,
+                    input.NdiBandwidth));
                 break;
             case InputKind.Uvc:
                 Commands.TryEnqueue(new StartUvcCommand(input.Id, dialog.ResultPath!));

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -646,17 +646,22 @@ public partial class MainWindow : Window
         input.FrameBufferFrames = dialog.Kind is InputKind.Omt or InputKind.Ndi
             ? dialog.ResultFrameBufferFrames
             : 1;
-        input.BandwidthSave = dialog.Kind is InputKind.Omt or InputKind.Ndi
+        input.BandwidthSave = dialog.Kind == InputKind.Omt
             ? dialog.ResultSaveMode
             : BandwidthSave.NotOnPreviewOrProgram;
-        input.KeepFullOnMultiview = dialog.Kind is InputKind.Omt or InputKind.Ndi
+        input.KeepFullOnMultiview = dialog.Kind == InputKind.Omt
             && dialog.ResultKeepFullOnMultiview;
+        input.OmtQuality = dialog.Kind == InputKind.Omt ? dialog.ResultOmtQuality : OmtQuality.Default;
         if (keepLive)
         {
-            Commands.TryEnqueue(new LiveSaveCommand(
-                input.Id,
-                input.BandwidthSave,
-                input.KeepFullOnMultiview));
+            if (dialog.Kind == InputKind.Omt)
+            {
+                Commands.TryEnqueue(new LiveSaveCommand(
+                    input.Id,
+                    input.BandwidthSave,
+                    input.KeepFullOnMultiview,
+                    input.OmtQuality));
+            }
             return;
         }
         switch (dialog.Kind)
@@ -684,15 +689,14 @@ public partial class MainWindow : Window
                     dialog.ResultUseGpu,
                     dialog.ResultFrameBufferFrames,
                     input.BandwidthSave,
-                    input.KeepFullOnMultiview));
+                    input.KeepFullOnMultiview,
+                    input.OmtQuality));
                 break;
             case InputKind.Ndi:
                 Commands.TryEnqueue(new ConnectNdiCommand(
                     input.Id,
                     dialog.ResultPath!,
-                    dialog.ResultFrameBufferFrames,
-                    input.BandwidthSave,
-                    input.KeepFullOnMultiview));
+                    dialog.ResultFrameBufferFrames));
                 break;
             case InputKind.Uvc:
                 Commands.TryEnqueue(new StartUvcCommand(input.Id, dialog.ResultPath!));

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -624,7 +624,13 @@ public partial class MainWindow : Window
         var previousKind = input.Kind;
         var wasGenerator = previousKind is InputKind.Color or InputKind.Bars or InputKind.Black;
         var nowGenerator = dialog.Kind is InputKind.Color or InputKind.Bars;
-        if (replacing && !input.IsBuiltin && (!wasGenerator || !nowGenerator))
+        var keepLive = replacing
+            && input.Kind == dialog.Kind
+            && dialog.Kind is InputKind.Omt or InputKind.Ndi
+            && input.PathOrAddress == dialog.ResultPath
+            && input.UseGpu == (dialog.Kind == InputKind.Omt && dialog.ResultUseGpu)
+            && input.FrameBufferFrames == dialog.ResultFrameBufferFrames;
+        if (replacing && !keepLive && !input.IsBuiltin && (!wasGenerator || !nowGenerator))
         {
             Commands.TryEnqueue(new DropSourceCommand(input.Id));
             MixerNative.FlushAudio(input.Id);
@@ -640,6 +646,19 @@ public partial class MainWindow : Window
         input.FrameBufferFrames = dialog.Kind is InputKind.Omt or InputKind.Ndi
             ? dialog.ResultFrameBufferFrames
             : 1;
+        input.BandwidthSave = dialog.Kind is InputKind.Omt or InputKind.Ndi
+            ? dialog.ResultSaveMode
+            : BandwidthSave.NotOnPreviewOrProgram;
+        input.KeepFullOnMultiview = dialog.Kind is InputKind.Omt or InputKind.Ndi
+            && dialog.ResultKeepFullOnMultiview;
+        if (keepLive)
+        {
+            Commands.TryEnqueue(new LiveSaveCommand(
+                input.Id,
+                input.BandwidthSave,
+                input.KeepFullOnMultiview));
+            return;
+        }
         switch (dialog.Kind)
         {
             case InputKind.Color:
@@ -663,13 +682,17 @@ public partial class MainWindow : Window
                     input.Id,
                     dialog.ResultPath!,
                     dialog.ResultUseGpu,
-                    dialog.ResultFrameBufferFrames));
+                    dialog.ResultFrameBufferFrames,
+                    input.BandwidthSave,
+                    input.KeepFullOnMultiview));
                 break;
             case InputKind.Ndi:
                 Commands.TryEnqueue(new ConnectNdiCommand(
                     input.Id,
                     dialog.ResultPath!,
-                    dialog.ResultFrameBufferFrames));
+                    dialog.ResultFrameBufferFrames,
+                    input.BandwidthSave,
+                    input.KeepFullOnMultiview));
                 break;
             case InputKind.Uvc:
                 Commands.TryEnqueue(new StartUvcCommand(input.Id, dialog.ResultPath!));

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -637,7 +637,9 @@ public partial class MainWindow : Window
         input.ColorB = dialog.ColorB;
         input.Scroll = dialog.Scroll;
         input.UseGpu = dialog.Kind == InputKind.Omt && dialog.ResultUseGpu;
-        input.FrameBufferFrames = dialog.Kind == InputKind.Omt ? dialog.ResultFrameBufferFrames : 1;
+        input.FrameBufferFrames = dialog.Kind is InputKind.Omt or InputKind.Ndi
+            ? dialog.ResultFrameBufferFrames
+            : 1;
         switch (dialog.Kind)
         {
             case InputKind.Color:
@@ -661,6 +663,12 @@ public partial class MainWindow : Window
                     input.Id,
                     dialog.ResultPath!,
                     dialog.ResultUseGpu,
+                    dialog.ResultFrameBufferFrames));
+                break;
+            case InputKind.Ndi:
+                Commands.TryEnqueue(new ConnectNdiCommand(
+                    input.Id,
+                    dialog.ResultPath!,
                     dialog.ResultFrameBufferFrames));
                 break;
             case InputKind.Uvc:
@@ -988,7 +996,7 @@ public partial class MainWindow : Window
                 continue;
             if (prior is not null)
                 Commands.TryEnqueue(new RemoveOutputCommand(output.Id));
-            if (output.Transport == OutputTransport.Omt)
+            if (output.Transport is OutputTransport.Omt or OutputTransport.Ndi)
             {
                 Commands.TryEnqueue(new AddOutputCommand(output));
                 continue;

--- a/host/Session.cs
+++ b/host/Session.cs
@@ -22,6 +22,14 @@ public enum BandwidthSave
     AlwaysFull = 3
 }
 
+public enum OmtQuality
+{
+    Default = 0,
+    Low = 1,
+    Medium = 50,
+    High = 100
+}
+
 public enum OutputTransport
 {
     Omt = 0,
@@ -70,6 +78,7 @@ public sealed class InputEntry
     public uint FrameBufferFrames { get; set; } = 1;
     public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
     public bool KeepFullOnMultiview { get; set; }
+    public OmtQuality OmtQuality { get; set; } = OmtQuality.Default;
     public bool IsBuiltin => Id is MixerNative.Color or MixerNative.Bars or MixerNative.Black or MixerNative.Blue;
     public override string ToString() => Name;
 }

--- a/host/Session.cs
+++ b/host/Session.cs
@@ -30,6 +30,12 @@ public enum OmtQuality
     High = 100
 }
 
+public enum NdiBandwidth
+{
+    Highest = 0,
+    Lowest = 1
+}
+
 public enum OutputTransport
 {
     Omt = 0,
@@ -79,6 +85,7 @@ public sealed class InputEntry
     public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
     public bool KeepFullOnMultiview { get; set; }
     public OmtQuality OmtQuality { get; set; } = OmtQuality.Default;
+    public NdiBandwidth NdiBandwidth { get; set; } = NdiBandwidth.Highest;
     public bool IsBuiltin => Id is MixerNative.Color or MixerNative.Bars or MixerNative.Black or MixerNative.Blue;
     public override string ToString() => Name;
 }

--- a/host/Session.cs
+++ b/host/Session.cs
@@ -14,6 +14,14 @@ public enum InputKind
     Uvc
 }
 
+public enum BandwidthSave
+{
+    AlwaysLow = 0,
+    NotOnProgram = 1,
+    NotOnPreviewOrProgram = 2,
+    AlwaysFull = 3
+}
+
 public enum OutputTransport
 {
     Omt = 0,
@@ -60,6 +68,8 @@ public sealed class InputEntry
     public bool Mute { get; set; }
     public bool UseGpu { get; set; }
     public uint FrameBufferFrames { get; set; } = 1;
+    public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
+    public bool KeepFullOnMultiview { get; set; }
     public bool IsBuiltin => Id is MixerNative.Color or MixerNative.Bars or MixerNative.Black or MixerNative.Blue;
     public override string ToString() => Name;
 }

--- a/host/SessionStore.cs
+++ b/host/SessionStore.cs
@@ -138,6 +138,8 @@ internal static class SessionStore
         public bool Mute { get; set; }
         public bool UseGpu { get; set; }
         public uint FrameBufferFrames { get; set; } = 1;
+        public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
+        public bool KeepFullOnMultiview { get; set; }
 
         public static InputDto From(InputEntry input) => new()
         {
@@ -153,7 +155,9 @@ internal static class SessionStore
             Gain = input.Gain,
             Mute = input.Mute,
             UseGpu = input.UseGpu,
-            FrameBufferFrames = input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u)
+            FrameBufferFrames = input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+            BandwidthSave = input.BandwidthSave,
+            KeepFullOnMultiview = input.KeepFullOnMultiview
         };
 
         public InputEntry ToEntry() => new()
@@ -170,7 +174,9 @@ internal static class SessionStore
             Gain = MixerNative.MixerGain(Gain),
             Mute = Mute,
             UseGpu = UseGpu,
-            FrameBufferFrames = FrameBufferFrames == 0 ? 1 : Math.Clamp(FrameBufferFrames, 1u, 8u)
+            FrameBufferFrames = FrameBufferFrames == 0 ? 1 : Math.Clamp(FrameBufferFrames, 1u, 8u),
+            BandwidthSave = BandwidthSave,
+            KeepFullOnMultiview = KeepFullOnMultiview
         };
     }
 

--- a/host/SessionStore.cs
+++ b/host/SessionStore.cs
@@ -141,6 +141,7 @@ internal static class SessionStore
         public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
         public bool KeepFullOnMultiview { get; set; }
         public OmtQuality OmtQuality { get; set; } = OmtQuality.Default;
+        public NdiBandwidth NdiBandwidth { get; set; } = NdiBandwidth.Highest;
 
         public static InputDto From(InputEntry input) => new()
         {
@@ -159,7 +160,8 @@ internal static class SessionStore
             FrameBufferFrames = input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
             BandwidthSave = input.BandwidthSave,
             KeepFullOnMultiview = input.KeepFullOnMultiview,
-            OmtQuality = input.OmtQuality
+            OmtQuality = input.OmtQuality,
+            NdiBandwidth = input.NdiBandwidth
         };
 
         public InputEntry ToEntry() => new()
@@ -179,7 +181,8 @@ internal static class SessionStore
             FrameBufferFrames = FrameBufferFrames == 0 ? 1 : Math.Clamp(FrameBufferFrames, 1u, 8u),
             BandwidthSave = BandwidthSave,
             KeepFullOnMultiview = KeepFullOnMultiview,
-            OmtQuality = OmtQuality
+            OmtQuality = OmtQuality,
+            NdiBandwidth = NdiBandwidth
         };
     }
 

--- a/host/SessionStore.cs
+++ b/host/SessionStore.cs
@@ -140,6 +140,7 @@ internal static class SessionStore
         public uint FrameBufferFrames { get; set; } = 1;
         public BandwidthSave BandwidthSave { get; set; } = BandwidthSave.NotOnPreviewOrProgram;
         public bool KeepFullOnMultiview { get; set; }
+        public OmtQuality OmtQuality { get; set; } = OmtQuality.Default;
 
         public static InputDto From(InputEntry input) => new()
         {
@@ -157,7 +158,8 @@ internal static class SessionStore
             UseGpu = input.UseGpu,
             FrameBufferFrames = input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
             BandwidthSave = input.BandwidthSave,
-            KeepFullOnMultiview = input.KeepFullOnMultiview
+            KeepFullOnMultiview = input.KeepFullOnMultiview,
+            OmtQuality = input.OmtQuality
         };
 
         public InputEntry ToEntry() => new()
@@ -176,7 +178,8 @@ internal static class SessionStore
             UseGpu = UseGpu,
             FrameBufferFrames = FrameBufferFrames == 0 ? 1 : Math.Clamp(FrameBufferFrames, 1u, 8u),
             BandwidthSave = BandwidthSave,
-            KeepFullOnMultiview = KeepFullOnMultiview
+            KeepFullOnMultiview = KeepFullOnMultiview,
+            OmtQuality = OmtQuality
         };
     }
 

--- a/mixer/Cargo.lock
+++ b/mixer/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +52,26 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "bit-set"
@@ -113,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +161,17 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -214,6 +263,7 @@ name = "eiviz_mixer"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "grafton-ndi",
  "image",
  "openmediatransport",
  "pollster",
@@ -314,6 +364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +402,18 @@ dependencies = [
  "presser",
  "thiserror",
  "windows",
+]
+
+[[package]]
+name = "grafton-ndi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c5135de4b600d1f1de31d89033457faab08f215204b90066591bf1a05c6aa6"
+dependencies = [
+ "bindgen",
+ "num_enum",
+ "once_cell",
+ "thiserror",
 ]
 
 [[package]]
@@ -413,6 +481,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -536,6 +613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,7 +670,7 @@ dependencies = [
  "naga-types",
  "num-traits",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror",
  "unicode-ident",
@@ -601,7 +684,7 @@ checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "thiserror",
 ]
 
@@ -615,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +715,28 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -816,6 +931,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +1033,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1081,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
@@ -960,6 +1129,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -1082,6 +1257,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1281,7 +1486,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "wgpu-core-deps-apple",
@@ -1527,6 +1732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytemuck = { version = "1.25", features = ["derive"] }
+grafton-ndi = { version = "1.0", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", features = ["wgpu"] }
 pollster = "0.4"

--- a/mixer/build.rs
+++ b/mixer/build.rs
@@ -1,0 +1,45 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=NDI_SDK_DIR");
+    if env::var("CARGO_CFG_WINDOWS").is_err() {
+        return;
+    }
+    let Some(dll) = ndi_runtime_dll() else {
+        return;
+    };
+    println!("cargo:rerun-if-changed={}", dll.display());
+    let Ok(out_dir) = env::var("OUT_DIR") else {
+        return;
+    };
+    // OUT_DIR = target/<profile>/build/<crate>/out → profile dir is three ancestors up.
+    let Some(profile_dir) = Path::new(&out_dir).ancestors().nth(3) else {
+        return;
+    };
+    copy_dll(&dll, &profile_dir.join("Processing.NDI.Lib.x64.dll"));
+    copy_dll(&dll, &profile_dir.join("deps").join("Processing.NDI.Lib.x64.dll"));
+}
+
+fn ndi_runtime_dll() -> Option<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(dir) = env::var("NDI_SDK_DIR") {
+        roots.push(PathBuf::from(dir));
+    }
+    roots.push(PathBuf::from(r"C:\Program Files\NDI\NDI 6 SDK"));
+    for root in roots {
+        let dll = root.join(r"Bin\x64\Processing.NDI.Lib.x64.dll");
+        if dll.is_file() {
+            return Some(dll);
+        }
+    }
+    None
+}
+
+fn copy_dll(src: &Path, dest: &Path) {
+    if let Some(parent) = dest.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::copy(src, dest);
+}

--- a/mixer/src/abi.rs
+++ b/mixer/src/abi.rs
@@ -42,6 +42,12 @@ pub const SRC_KIND_INPUT: u32 = 4;
 pub const GEN_SOLID: u32 = 0;
 pub const GEN_BARS: u32 = 1;
 
+pub const SAVE_ALWAYS_LOW: u32 = 0;
+pub const SAVE_NOT_ON_PROGRAM: u32 = 1;
+pub const SAVE_NOT_ON_PREVIEW_OR_PROGRAM: u32 = 2;
+pub const SAVE_ALWAYS_FULL: u32 = 3;
+pub const SAVE_FLAG_MULTIVIEW: u32 = 1;
+
 pub const MV_SLOT_MAX: usize = 16;
 pub const MU_BUS_PREVIEW: u64 = 0x1000_0000_0000_0000;
 pub const MU_BUS_MULTIVIEW: u64 = 0x2000_0000_0000_0000;

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -13,14 +13,15 @@ mod omt;
 mod pool;
 mod present;
 mod readback;
+mod save;
 mod upload;
 
 pub use abi::{
     AudioPeak, MixerStats, OverlayDesc, Rect, SourceUsage, UnitState, ERR_ALREADY_CREATED, ERR_DEVICE,
     ERR_INVALID_ARGUMENT, ERR_IO, ERR_NOT_CREATED, GEN_BARS, GEN_SOLID, OK, OUTPUT_MULTIVIEW,
-    OUTPUT_PREVIEW, OUTPUT_PROGRAM, OUT_DECKLINK, OUT_NDI, OUT_OMT, SCENE_BASE, SRC_BARS, SRC_BLACK,
-    SRC_BLUE, SRC_COLOR, SRC_KIND_INPUT, SRC_KIND_MU_MULTIVIEW, SRC_KIND_MU_PREVIEW,
-    SRC_KIND_MU_PROGRAM, SRC_KIND_SCENE,
+    OUTPUT_PREVIEW, OUTPUT_PROGRAM, OUT_DECKLINK, OUT_NDI, OUT_OMT, SAVE_FLAG_MULTIVIEW,
+    SAVE_NOT_ON_PREVIEW_OR_PROGRAM, SCENE_BASE, SRC_BARS, SRC_BLACK, SRC_BLUE, SRC_COLOR,
+    SRC_KIND_INPUT, SRC_KIND_MU_MULTIVIEW, SRC_KIND_MU_PREVIEW, SRC_KIND_MU_PROGRAM, SRC_KIND_SCENE,
 };
 pub use audio::{AudioBusInfo, AudioDeviceInfo};
 pub use media::MixerVideoInfo;
@@ -43,6 +44,7 @@ use ndi::{NdiReceiver, NdiSender};
 use omt::{omt_gpu_from_device, GpuSendStore, OmtGpu, OmtReceiver, ProgramSender};
 use present::Presenters;
 use readback::ReadbackStore;
+use save::{collect_source_roles, want_full, LiveSave};
 use upload::{AudioPacket, CpuFormat, UploadStore, AUDIO_RATE};
 
 struct AutoTransition {
@@ -105,6 +107,7 @@ struct Shared {
     videos: HashMap<u64, VideoPump>,
     outputs: HashMap<u64, LiveOutput>,
     generators: HashMap<u64, Generator>,
+    live_save: HashMap<u64, LiveSave>,
     multiview_binds: HashMap<u64, (u64, u64)>,
     last_error: String,
     last_render_ms: f32,
@@ -117,6 +120,15 @@ struct Shared {
 enum LiveReceiver {
     Omt(OmtReceiver),
     Ndi(NdiReceiver),
+}
+
+impl LiveReceiver {
+    fn apply_save(&self, full: bool, on_program: bool, on_preview: bool) {
+        match self {
+            Self::Omt(receiver) => receiver.apply_save(full, on_program, on_preview),
+            Self::Ndi(receiver) => receiver.apply_save(full),
+        }
+    }
 }
 
 enum OutputHandle {
@@ -331,6 +343,7 @@ pub extern "C" fn mixer_create(_adapter_luid: u64, fps_num: u32, fps_den: u32) -
         videos: HashMap::new(),
         outputs: HashMap::new(),
         generators: HashMap::new(),
+        live_save: HashMap::new(),
         last_error: String::new(),
         last_render_ms: 0.0,
         frame_buffer_frames: 3,
@@ -374,6 +387,9 @@ pub extern "C" fn mixer_create(_adapter_luid: u64, fps_num: u32, fps_den: u32) -
         send: Some(send),
         stop,
     });
+    let _ = thread::Builder::new()
+        .name("eiviz-ndi-find".into())
+        .spawn(ndi::warm_finder);
     OK
 }
 
@@ -1071,6 +1087,24 @@ pub unsafe extern "C" fn mixer_ndi_connect(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn mixer_set_live_save(id: u64, mode: u32, flags: u32) -> i32 {
+    if id == 0 {
+        return ERR_INVALID_ARGUMENT;
+    }
+    with_mixer(|mixer| {
+        mixer.shared.lock().expect("shared").live_save.insert(
+            id,
+            LiveSave {
+                mode,
+                flags: flags & SAVE_FLAG_MULTIVIEW,
+            },
+        );
+        OK
+    })
+    .unwrap_or_else(|code| code)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mixer_omt_start_send(unit_id: u64, name: *const c_char) -> i32 {
     if name.is_null() {
         return ERR_INVALID_ARGUMENT;
@@ -1192,16 +1226,19 @@ pub unsafe extern "C" fn mixer_ndi_discover(out: *mut u8, cap: usize) -> i32 {
     if out.is_null() {
         return ERR_INVALID_ARGUMENT;
     }
-    match ndi::discover_sources() {
-        Ok(addresses) => {
-            let text = addresses.join("\n");
-            let bytes = text.as_bytes();
-            let n = bytes.len().min(cap);
-            unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), out, n) };
-            n as i32
+        match ndi::discover_sources() {
+            Ok(addresses) => {
+                let text = addresses.join("\n");
+                let bytes = text.as_bytes();
+                let n = bytes.len().min(cap);
+                unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), out, n) };
+                n as i32
+            }
+            Err(error) => {
+                let _ = with_mixer(|mixer| set_error(&mixer.shared, error));
+                0
+            }
         }
-        Err(_) => 0,
-    }
 }
 
 #[unsafe(no_mangle)]
@@ -1263,6 +1300,7 @@ pub extern "C" fn mixer_destroy_source(id: u64) -> i32 {
                 {
                     shared.receivers.remove(&id);
                     shared.generators.remove(&id);
+                    shared.live_save.remove(&id);
                     shared.uploads.clone()
                 },
             )
@@ -1922,12 +1960,31 @@ fn render_loop(
                 tallies.insert(*scene_id, (preview_source, program_source));
             }
             frame_i = frame_i.wrapping_add(1);
+            let monitor_sources = presenters.attached_monitor_sources_due(frame_i);
             let (used_scenes, used_uploads) = collect_live_ids(
                 &scene_specs,
                 &snapshot,
-                presenters.attached_monitor_sources_due(frame_i),
+                monitor_sources.clone(),
                 &outputs_snap,
             );
+            let output_refs: Vec<(u32, u64)> = outputs_snap
+                .iter()
+                .map(|item| (item.source_kind, item.source_id))
+                .collect();
+            let roles = collect_source_roles(
+                &scene_specs,
+                &snapshot,
+                &monitor_sources,
+                &output_refs,
+            );
+            {
+                let guard = shared.lock().expect("shared");
+                for (id, receiver) in &guard.receivers {
+                    let save = guard.live_save.get(id).copied().unwrap_or_default();
+                    let role = roles.get(id).copied().unwrap_or_default();
+                    receiver.apply_save(want_full(save, role), role.on_program, role.on_preview);
+                }
+            }
             let mut upload_guard = uploads.lock().expect("uploads");
             let frame_begin = Instant::now();
             let pts = (clock_start.elapsed().as_nanos() / 100) as i64;

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -126,7 +126,8 @@ impl LiveReceiver {
     fn apply_save(&self, full: bool, on_program: bool, on_preview: bool) {
         match self {
             Self::Omt(receiver) => receiver.apply_save(full, on_program, on_preview),
-            Self::Ndi(receiver) => receiver.apply_save(full),
+            // NDI bandwidth save needs Advanced SDK; see NdiReceiver.
+            Self::Ndi(_) => {}
         }
     }
 }
@@ -1000,6 +1001,7 @@ pub unsafe extern "C" fn mixer_omt_connect(
     address: *const c_char,
     use_gpu: u32,
     frame_buffer_frames: u32,
+    quality: u32,
 ) -> i32 {
     if address.is_null() {
         return ERR_INVALID_ARGUMENT;
@@ -1024,7 +1026,7 @@ pub unsafe extern "C" fn mixer_omt_connect(
             drop(previous);
             (uploads, gpu)
         };
-        match OmtReceiver::start(id, address, uploads, gpu, depth) {
+        match OmtReceiver::start(id, address, uploads, gpu, depth, quality) {
             Ok(receiver) => {
                 mixer
                     .shared
@@ -1099,6 +1101,21 @@ pub extern "C" fn mixer_set_live_save(id: u64, mode: u32, flags: u32) -> i32 {
                 flags: flags & SAVE_FLAG_MULTIVIEW,
             },
         );
+        OK
+    })
+    .unwrap_or_else(|code| code)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn mixer_omt_set_quality(id: u64, quality: u32) -> i32 {
+    if id == 0 {
+        return ERR_INVALID_ARGUMENT;
+    }
+    with_mixer(|mixer| {
+        let shared = mixer.shared.lock().expect("shared");
+        if let Some(LiveReceiver::Omt(receiver)) = shared.receivers.get(&id) {
+            receiver.set_quality(quality);
+        }
         OK
     })
     .unwrap_or_else(|code| code)
@@ -1960,11 +1977,12 @@ fn render_loop(
                 tallies.insert(*scene_id, (preview_source, program_source));
             }
             frame_i = frame_i.wrapping_add(1);
-            let monitor_sources = presenters.attached_monitor_sources_due(frame_i);
+            let monitor_sources_due = presenters.attached_monitor_sources_due(frame_i);
+            let monitor_sources = presenters.attached_monitor_sources();
             let (used_scenes, used_uploads) = collect_live_ids(
                 &scene_specs,
                 &snapshot,
-                monitor_sources.clone(),
+                monitor_sources_due,
                 &outputs_snap,
             );
             let output_refs: Vec<(u32, u64)> = outputs_snap

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -8,6 +8,7 @@ mod convert;
 mod device;
 mod dxgi;
 mod media;
+mod ndi;
 mod omt;
 mod pool;
 mod present;
@@ -38,6 +39,7 @@ use delay::FrameDelay;
 use device::GpuDevice;
 use dxgi::GpuVideoContext;
 use media::VideoPump;
+use ndi::{NdiReceiver, NdiSender};
 use omt::{omt_gpu_from_device, GpuSendStore, OmtGpu, OmtReceiver, ProgramSender};
 use present::Presenters;
 use readback::ReadbackStore;
@@ -99,7 +101,7 @@ struct Shared {
     uploads: Arc<Mutex<UploadStore>>,
     gpu_video: GpuVideoContext,
     omt_gpu: OmtGpu,
-    receivers: HashMap<u64, OmtReceiver>,
+    receivers: HashMap<u64, LiveReceiver>,
     videos: HashMap<u64, VideoPump>,
     outputs: HashMap<u64, LiveOutput>,
     generators: HashMap<u64, Generator>,
@@ -112,10 +114,77 @@ struct Shared {
     audio: audio::AudioEngine,
 }
 
+enum LiveReceiver {
+    Omt(OmtReceiver),
+    Ndi(NdiReceiver),
+}
+
+enum OutputHandle {
+    Omt(ProgramSender),
+    Ndi(NdiSender),
+}
+
+impl OutputHandle {
+    fn pump(&mut self) -> Result<bool, String> {
+        match self {
+            Self::Omt(sender) => {
+                sender.pump()?;
+                Ok(sender.video_subscribed())
+            }
+            Self::Ndi(sender) => sender.pump(),
+        }
+    }
+
+    fn send_video_uyvy(
+        &mut self,
+        width: u32,
+        height: u32,
+        stride: u32,
+        pts: i64,
+        data: Arc<[u8]>,
+        fps_n: u32,
+        fps_d: u32,
+    ) -> Result<(), String> {
+        match self {
+            Self::Omt(sender) => {
+                sender.send_video_uyvy(width, height, stride, pts, data, fps_n, fps_d)
+            }
+            Self::Ndi(sender) => {
+                sender.send_video_uyvy(width, height, stride, pts, &data, fps_n, fps_d)
+            }
+        }
+    }
+
+    fn send_video_texture(
+        &mut self,
+        omt_gpu: &OmtGpu,
+        texture: &wgpu::Texture,
+        width: u32,
+        height: u32,
+        pts: i64,
+        fps_n: u32,
+        fps_d: u32,
+    ) -> Result<(), String> {
+        match self {
+            Self::Omt(sender) => {
+                sender.send_video_texture(omt_gpu, texture, width, height, pts, fps_n, fps_d)
+            }
+            Self::Ndi(_) => Ok(()),
+        }
+    }
+
+    fn send_audio(&mut self, packet: &AudioPacket) -> Result<(), String> {
+        match self {
+            Self::Omt(sender) => sender.send_audio(packet),
+            Self::Ndi(sender) => sender.send_audio(packet),
+        }
+    }
+}
+
 enum SendCmd {
     Add {
         output_id: u64,
-        sender: ProgramSender,
+        sender: OutputHandle,
         video_sub: Arc<AtomicBool>,
     },
     Remove {
@@ -941,7 +1010,55 @@ pub unsafe extern "C" fn mixer_omt_connect(
         };
         match OmtReceiver::start(id, address, uploads, gpu, depth) {
             Ok(receiver) => {
-                mixer.shared.lock().expect("shared").receivers.insert(id, receiver);
+                mixer
+                    .shared
+                    .lock()
+                    .expect("shared")
+                    .receivers
+                    .insert(id, LiveReceiver::Omt(receiver));
+                OK
+            }
+            Err(error) => {
+                set_error(&mixer.shared, error);
+                ERR_IO
+            }
+        }
+    })
+    .unwrap_or_else(|code| code)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mixer_ndi_connect(
+    id: u64,
+    address: *const c_char,
+    frame_buffer_frames: u32,
+) -> i32 {
+    if address.is_null() {
+        return ERR_INVALID_ARGUMENT;
+    }
+    let address = unsafe { CStr::from_ptr(address) }
+        .to_str()
+        .unwrap_or_default()
+        .to_string();
+    let depth = frame_buffer_frames.clamp(1, 8);
+    with_mixer(|mixer| {
+        let uploads = {
+            let mut shared = mixer.shared.lock().expect("shared");
+            let previous = shared.videos.remove(&id);
+            drop(shared.receivers.remove(&id));
+            let uploads = shared.uploads.clone();
+            drop(shared);
+            drop(previous);
+            uploads
+        };
+        match NdiReceiver::start(id, address, uploads, depth) {
+            Ok(receiver) => {
+                mixer
+                    .shared
+                    .lock()
+                    .expect("shared")
+                    .receivers
+                    .insert(id, LiveReceiver::Ndi(receiver));
                 OK
             }
             Err(error) => {
@@ -978,35 +1095,47 @@ pub unsafe extern "C" fn mixer_output_add(
         .to_str()
         .unwrap_or_default()
         .to_string();
-    match transport {
-        OUT_NDI => {
-            let _ = with_mixer(|mixer| {
-                set_error(&mixer.shared, "NDI output is not linked in this build");
-            });
-            return ERR_IO;
-        }
-        OUT_DECKLINK => {
-            let _ = with_mixer(|mixer| {
-                set_error(&mixer.shared, "DeckLink output is not linked in this build");
-            });
-            return ERR_IO;
-        }
-        OUT_OMT => {}
-        _ => return ERR_INVALID_ARGUMENT,
+    if transport == OUT_DECKLINK {
+        let _ = with_mixer(|mixer| {
+            set_error(&mixer.shared, "DeckLink output is not linked in this build");
+        });
+        return ERR_IO;
     }
-    let started = panic::catch_unwind(AssertUnwindSafe(|| ProgramSender::start(&name)));
-    let sender = match started {
-        Ok(Ok(sender)) => sender,
-        Ok(Err(error)) => {
-            let _ = with_mixer(|mixer| set_error(&mixer.shared, error));
-            return ERR_IO;
+    let use_gpu = transport == OUT_OMT && use_gpu != 0;
+    let handle = match transport {
+        OUT_NDI => {
+            let started = panic::catch_unwind(AssertUnwindSafe(|| NdiSender::start(&name)));
+            match started {
+                Ok(Ok(sender)) => OutputHandle::Ndi(sender),
+                Ok(Err(error)) => {
+                    let _ = with_mixer(|mixer| set_error(&mixer.shared, error));
+                    return ERR_IO;
+                }
+                Err(_) => {
+                    let _ = with_mixer(|mixer| {
+                        set_error(&mixer.shared, "NDI sender panicked during create")
+                    });
+                    return ERR_IO;
+                }
+            }
         }
-        Err(_) => {
-            let _ = with_mixer(|mixer| {
-                set_error(&mixer.shared, "OMT sender panicked during create")
-            });
-            return ERR_IO;
+        OUT_OMT => {
+            let started = panic::catch_unwind(AssertUnwindSafe(|| ProgramSender::start(&name)));
+            match started {
+                Ok(Ok(sender)) => OutputHandle::Omt(sender),
+                Ok(Err(error)) => {
+                    let _ = with_mixer(|mixer| set_error(&mixer.shared, error));
+                    return ERR_IO;
+                }
+                Err(_) => {
+                    let _ = with_mixer(|mixer| {
+                        set_error(&mixer.shared, "OMT sender panicked during create")
+                    });
+                    return ERR_IO;
+                }
+            }
         }
+        _ => return ERR_INVALID_ARGUMENT,
     };
     with_mixer(|mixer| {
         let video_sub = Arc::new(AtomicBool::new(false));
@@ -1018,12 +1147,12 @@ pub unsafe extern "C" fn mixer_output_add(
                 source_id,
                 unit_id,
                 video_sub: Arc::clone(&video_sub),
-                use_gpu: use_gpu != 0,
+                use_gpu,
             },
         );
         let _ = mixer.send_tx.send(SendCmd::Add {
             output_id,
-            sender,
+            sender: handle,
             video_sub,
         });
         OK
@@ -1047,6 +1176,23 @@ pub unsafe extern "C" fn mixer_omt_discover(out: *mut u8, cap: usize) -> i32 {
         return ERR_INVALID_ARGUMENT;
     }
     match omt::discover_addresses() {
+        Ok(addresses) => {
+            let text = addresses.join("\n");
+            let bytes = text.as_bytes();
+            let n = bytes.len().min(cap);
+            unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), out, n) };
+            n as i32
+        }
+        Err(_) => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mixer_ndi_discover(out: *mut u8, cap: usize) -> i32 {
+    if out.is_null() {
+        return ERR_INVALID_ARGUMENT;
+    }
+    match ndi::discover_sources() {
         Ok(addresses) => {
             let text = addresses.join("\n");
             let bytes = text.as_bytes();
@@ -2269,7 +2415,7 @@ fn collect_live_ids(
 }
 
 fn send_loop(rx: mpsc::Receiver<SendCmd>, stop: Arc<AtomicBool>, omt_gpu: OmtGpu) {
-    let mut senders: HashMap<u64, (ProgramSender, Arc<AtomicBool>)> = HashMap::new();
+    let mut senders: HashMap<u64, (OutputHandle, Arc<AtomicBool>)> = HashMap::new();
     while !stop.load(Ordering::Relaxed) {
         loop {
             match rx.try_recv() {
@@ -2283,8 +2429,8 @@ fn send_loop(rx: mpsc::Receiver<SendCmd>, stop: Arc<AtomicBool>, omt_gpu: OmtGpu
         for (&id, (sender, video_sub)) in senders.iter_mut() {
             let pumped = panic::catch_unwind(AssertUnwindSafe(|| sender.pump()));
             match pumped {
-                Ok(_) => video_sub.store(sender.video_subscribed(), Ordering::Relaxed),
-                Err(_) => dead.push(id),
+                Ok(Ok(subscribed)) => video_sub.store(subscribed, Ordering::Relaxed),
+                Ok(Err(_)) | Err(_) => dead.push(id),
             }
         }
         for id in dead {
@@ -2300,7 +2446,7 @@ fn send_loop(rx: mpsc::Receiver<SendCmd>, stop: Arc<AtomicBool>, omt_gpu: OmtGpu
 }
 
 fn apply_send_cmd(
-    senders: &mut HashMap<u64, (ProgramSender, Arc<AtomicBool>)>,
+    senders: &mut HashMap<u64, (OutputHandle, Arc<AtomicBool>)>,
     cmd: SendCmd,
     omt_gpu: &OmtGpu,
 ) {

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -1050,6 +1050,7 @@ pub unsafe extern "C" fn mixer_ndi_connect(
     id: u64,
     address: *const c_char,
     frame_buffer_frames: u32,
+    low_bandwidth: u32,
 ) -> i32 {
     if address.is_null() {
         return ERR_INVALID_ARGUMENT;
@@ -1069,7 +1070,7 @@ pub unsafe extern "C" fn mixer_ndi_connect(
             drop(previous);
             uploads
         };
-        match NdiReceiver::start(id, address, uploads, depth) {
+        match NdiReceiver::start(id, address, uploads, depth, low_bandwidth) {
             Ok(receiver) => {
                 mixer
                     .shared

--- a/mixer/src/ndi.rs
+++ b/mixer/src/ndi.rs
@@ -41,7 +41,6 @@ pub fn warm_finder() {
 
 pub struct NdiReceiver {
     stop: Arc<AtomicBool>,
-    want_full: Arc<AtomicBool>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -55,11 +54,12 @@ impl NdiReceiver {
         let depth = frame_buffer_frames.clamp(1, 8);
         let ndi = runtime()?;
         let source = resolve_source(&address)?;
-        let want_full = Arc::new(AtomicBool::new(true));
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
-        let want_full_thread = Arc::clone(&want_full);
-        let mut receiver = open_receiver(ndi, &source, source_id, true)?;
+        // NDI public SDK sets bandwidth at create time only. Dynamic Highest/Lowest
+        // needs Advanced SDK 6.1 `NDIlib_recv_set_bandwidth` (Vendor ID). Implement
+        // that path when Advanced SDK is available.
+        let receiver = open_receiver(ndi, &source, source_id)?;
         let join = thread::Builder::new()
             .name(format!("eiviz-ndi-{source_id}"))
             .spawn(move || {
@@ -73,15 +73,7 @@ impl NdiReceiver {
                         depth,
                     );
                 }
-                let mut full = true;
                 while !stop_thread.load(Ordering::Relaxed) {
-                    let next_full = want_full_thread.load(Ordering::Relaxed);
-                    if next_full != full
-                        && let Ok(next) = open_receiver(ndi, &source, source_id, next_full)
-                    {
-                        receiver = next;
-                        full = next_full;
-                    }
                     match receiver.video().try_capture(Duration::from_millis(4)) {
                         Ok(Some(frame)) => ingest_video(&uploads, source_id, depth, &frame),
                         Ok(None) => {}
@@ -100,13 +92,8 @@ impl NdiReceiver {
             .map_err(|error| error.to_string())?;
         Ok(Self {
             stop,
-            want_full,
             join: Some(join),
         })
-    }
-
-    pub fn apply_save(&self, full: bool) {
-        self.want_full.store(full, Ordering::Relaxed);
     }
 }
 
@@ -202,19 +189,10 @@ impl NdiSender {
     }
 }
 
-fn open_receiver(
-    ndi: &NDI,
-    source: &Source,
-    source_id: u64,
-    full: bool,
-) -> Result<Receiver, String> {
+fn open_receiver(ndi: &NDI, source: &Source, source_id: u64) -> Result<Receiver, String> {
     let options = ReceiverOptions::builder(source.clone())
         .color(ReceiverColorFormat::BGRX_BGRA)
-        .bandwidth(if full {
-            ReceiverBandwidth::Highest
-        } else {
-            ReceiverBandwidth::Lowest
-        })
+        .bandwidth(ReceiverBandwidth::Highest)
         .allow_video_fields(false)
         .name(format!("eiviz-ndi-{source_id}"))
         .build();

--- a/mixer/src/ndi.rs
+++ b/mixer/src/ndi.rs
@@ -4,14 +4,16 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use grafton_ndi::{
-    AudioFrame, Finder, FinderOptions, LineStrideOrSize, PixelFormat, Receiver, ReceiverColorFormat,
-    ReceiverOptions, Sender, SenderOptions, Source, VideoFrame, NDI,
+    AudioFrame, Finder, FinderOptions, LineStrideOrSize, PixelFormat, Receiver, ReceiverBandwidth,
+    ReceiverColorFormat, ReceiverOptions, Sender, SenderOptions, Source, SourceAddress, VideoFrame,
+    NDI,
 };
 
 use crate::abi::FMT_BGRA;
 use crate::upload::{ingest_audio_throttled, AudioPacket, CpuFormat, UploadStore};
 
 static RUNTIME: OnceLock<Result<NDI, String>> = OnceLock::new();
+static FINDER: OnceLock<Result<Finder, String>> = OnceLock::new();
 
 fn runtime() -> Result<&'static NDI, String> {
     match RUNTIME.get_or_init(|| NDI::new().map_err(|error| error.to_string())) {
@@ -20,8 +22,26 @@ fn runtime() -> Result<&'static NDI, String> {
     }
 }
 
+fn finder() -> Result<&'static Finder, String> {
+    match FINDER.get_or_init(|| {
+        let ndi = runtime()?;
+        Finder::new(ndi, &FinderOptions::builder().show_local_sources(true).build())
+            .map_err(|error| error.to_string())
+    }) {
+        Ok(finder) => Ok(finder),
+        Err(error) => Err(error.clone()),
+    }
+}
+
+pub fn warm_finder() {
+    if let Ok(finder) = finder() {
+        let _ = finder.wait_for_sources(Duration::from_secs(2));
+    }
+}
+
 pub struct NdiReceiver {
     stop: Arc<AtomicBool>,
+    want_full: Arc<AtomicBool>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -34,15 +54,12 @@ impl NdiReceiver {
     ) -> Result<Self, String> {
         let depth = frame_buffer_frames.clamp(1, 8);
         let ndi = runtime()?;
-        let source = resolve_source(ndi, &address)?;
-        let options = ReceiverOptions::builder(source)
-            .color(ReceiverColorFormat::BGRX_BGRA)
-            .allow_video_fields(false)
-            .name("eiviz")
-            .build();
-        let receiver = Receiver::new(ndi, &options).map_err(|error| error.to_string())?;
+        let source = resolve_source(&address)?;
+        let want_full = Arc::new(AtomicBool::new(true));
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
+        let want_full_thread = Arc::clone(&want_full);
+        let mut receiver = open_receiver(ndi, &source, source_id, true)?;
         let join = thread::Builder::new()
             .name(format!("eiviz-ndi-{source_id}"))
             .spawn(move || {
@@ -56,7 +73,15 @@ impl NdiReceiver {
                         depth,
                     );
                 }
+                let mut full = true;
                 while !stop_thread.load(Ordering::Relaxed) {
+                    let next_full = want_full_thread.load(Ordering::Relaxed);
+                    if next_full != full
+                        && let Ok(next) = open_receiver(ndi, &source, source_id, next_full)
+                    {
+                        receiver = next;
+                        full = next_full;
+                    }
                     match receiver.video().try_capture(Duration::from_millis(4)) {
                         Ok(Some(frame)) => ingest_video(&uploads, source_id, depth, &frame),
                         Ok(None) => {}
@@ -75,8 +100,13 @@ impl NdiReceiver {
             .map_err(|error| error.to_string())?;
         Ok(Self {
             stop,
+            want_full,
             join: Some(join),
         })
+    }
+
+    pub fn apply_save(&self, full: bool) {
+        self.want_full.store(full, Ordering::Relaxed);
     }
 }
 
@@ -172,49 +202,97 @@ impl NdiSender {
     }
 }
 
+fn open_receiver(
+    ndi: &NDI,
+    source: &Source,
+    source_id: u64,
+    full: bool,
+) -> Result<Receiver, String> {
+    let options = ReceiverOptions::builder(source.clone())
+        .color(ReceiverColorFormat::BGRX_BGRA)
+        .bandwidth(if full {
+            ReceiverBandwidth::Highest
+        } else {
+            ReceiverBandwidth::Lowest
+        })
+        .allow_video_fields(false)
+        .name(format!("eiviz-ndi-{source_id}"))
+        .build();
+    Receiver::new(ndi, &options).map_err(|error| error.to_string())
+}
+
 pub fn discover_sources() -> Result<Vec<String>, String> {
-    let ndi = runtime()?;
-    let finder = Finder::new(ndi, &FinderOptions::builder().show_local_sources(true).build())
-        .map_err(|error| error.to_string())?;
-    let _ = finder.wait_for_sources(Duration::from_millis(400));
-    let sources = finder
-        .current_sources()
-        .or_else(|_| finder.find_sources(Duration::from_millis(200)))
-        .map_err(|error| error.to_string())?;
+    let finder = finder()?;
+    let mut sources = finder.current_sources().unwrap_or_default();
+    if sources.is_empty() {
+        let _ = finder.wait_for_sources(Duration::from_millis(1500));
+        sources = finder
+            .current_sources()
+            .or_else(|_| finder.find_sources(Duration::from_millis(400)))
+            .map_err(|error| error.to_string())?;
+    }
     Ok(sources.into_iter().map(|source| source.to_string()).collect())
 }
 
-fn resolve_source(ndi: &NDI, query: &str) -> Result<Source, String> {
+fn resolve_source(query: &str) -> Result<Source, String> {
     let trimmed = query.trim();
     if trimmed.is_empty() {
         return Err("NDI source name is empty".into());
     }
-    let finder = Finder::new(ndi, &FinderOptions::builder().show_local_sources(true).build())
-        .map_err(|error| error.to_string())?;
-    let _ = finder.wait_for_sources(Duration::from_secs(2));
-    let sources = finder
-        .current_sources()
-        .or_else(|_| finder.find_sources(Duration::from_millis(500)))
-        .map_err(|error| error.to_string())?;
-    if let Some(source) = sources.iter().find(|source| source_key(source).eq_ignore_ascii_case(trimmed))
+    if let Ok(finder) = finder() {
+        let _ = finder.wait_for_sources(Duration::from_millis(200));
+        if let Ok(sources) = finder
+            .current_sources()
+            .or_else(|_| finder.find_sources(Duration::from_millis(400)))
+        {
+            if let Some(source) = sources
+                .iter()
+                .find(|source| source_key(source).eq_ignore_ascii_case(trimmed))
+            {
+                return Ok(source.clone());
+            }
+            if let Some(source) = sources
+                .iter()
+                .find(|source| source.name.eq_ignore_ascii_case(trimmed))
+            {
+                return Ok(source.clone());
+            }
+            let matches: Vec<_> = sources
+                .iter()
+                .filter(|source| {
+                    let needle = trimmed.to_ascii_lowercase();
+                    source_key(source).to_ascii_lowercase().contains(&needle)
+                        || source.name.to_ascii_lowercase().contains(&needle)
+                })
+                .cloned()
+                .collect();
+            if matches.len() == 1 {
+                return Ok(matches.into_iter().next().expect("len 1"));
+            }
+        }
+    }
+    Ok(source_from_query(trimmed))
+}
+
+pub(crate) fn source_from_query(query: &str) -> Source {
+    let trimmed = query.trim();
+    if let Some((name, addr)) = trimmed.rsplit_once('@')
+        && !name.is_empty()
+        && !addr.is_empty()
     {
-        return Ok(source.clone());
+        let address = if addr.contains("://") {
+            SourceAddress::Url(addr.to_string())
+        } else {
+            SourceAddress::Ip(addr.to_string())
+        };
+        return Source {
+            name: name.to_string(),
+            address,
+        };
     }
-    if let Some(source) = sources.iter().find(|source| source.name.eq_ignore_ascii_case(trimmed)) {
-        return Ok(source.clone());
-    }
-    let matches: Vec<_> = sources
-        .iter()
-        .filter(|source| {
-            source_key(source).to_ascii_lowercase().contains(&trimmed.to_ascii_lowercase())
-                || source.name.to_ascii_lowercase().contains(&trimmed.to_ascii_lowercase())
-        })
-        .cloned()
-        .collect();
-    match matches.len() {
-        1 => Ok(matches.into_iter().next().expect("len 1")),
-        0 => Err(format!("NDI source not found: {trimmed}")),
-        _ => Err(format!("NDI source name is ambiguous: {trimmed}")),
+    Source {
+        name: trimmed.to_string(),
+        address: SourceAddress::None,
     }
 }
 
@@ -308,5 +386,17 @@ mod tests {
         src[16..24].copy_from_slice(&[9, 10, 11, 12, 13, 14, 15, 16]);
         let packed = pack_uyvy(width, height, stride, &src);
         assert_eq!(packed, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    }
+
+    #[test]
+    fn source_from_query_keeps_name_and_url() {
+        let named = super::source_from_query("CAM 1");
+        assert_eq!(named.name, "CAM 1");
+        let with_ip = super::source_from_query("DESKTOP (CAM)@192.168.0.10:5960");
+        assert_eq!(with_ip.name, "DESKTOP (CAM)");
+        match with_ip.address {
+            grafton_ndi::SourceAddress::Ip(ip) => assert!(ip.starts_with("192.168.0.10")),
+            other => panic!("{other:?}"),
+        }
     }
 }

--- a/mixer/src/ndi.rs
+++ b/mixer/src/ndi.rs
@@ -50,16 +50,17 @@ impl NdiReceiver {
         address: String,
         uploads: Arc<Mutex<UploadStore>>,
         frame_buffer_frames: u32,
+        low_bandwidth: u32,
     ) -> Result<Self, String> {
         let depth = frame_buffer_frames.clamp(1, 8);
         let ndi = runtime()?;
         let source = resolve_source(&address)?;
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
-        // NDI public SDK sets bandwidth at create time only. Dynamic Highest/Lowest
+        // Bandwidth is chosen at create time. Dynamic Highest/Lowest switching
         // needs Advanced SDK 6.1 `NDIlib_recv_set_bandwidth` (Vendor ID). Implement
         // that path when Advanced SDK is available.
-        let receiver = open_receiver(ndi, &source, source_id)?;
+        let receiver = open_receiver(ndi, &source, source_id, low_bandwidth != 0)?;
         let join = thread::Builder::new()
             .name(format!("eiviz-ndi-{source_id}"))
             .spawn(move || {
@@ -189,10 +190,19 @@ impl NdiSender {
     }
 }
 
-fn open_receiver(ndi: &NDI, source: &Source, source_id: u64) -> Result<Receiver, String> {
+fn open_receiver(
+    ndi: &NDI,
+    source: &Source,
+    source_id: u64,
+    low_bandwidth: bool,
+) -> Result<Receiver, String> {
     let options = ReceiverOptions::builder(source.clone())
         .color(ReceiverColorFormat::BGRX_BGRA)
-        .bandwidth(ReceiverBandwidth::Highest)
+        .bandwidth(if low_bandwidth {
+            ReceiverBandwidth::Lowest
+        } else {
+            ReceiverBandwidth::Highest
+        })
         .allow_video_fields(false)
         .name(format!("eiviz-ndi-{source_id}"))
         .build();

--- a/mixer/src/ndi.rs
+++ b/mixer/src/ndi.rs
@@ -1,0 +1,312 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use grafton_ndi::{
+    AudioFrame, Finder, FinderOptions, LineStrideOrSize, PixelFormat, Receiver, ReceiverColorFormat,
+    ReceiverOptions, Sender, SenderOptions, Source, VideoFrame, NDI,
+};
+
+use crate::abi::FMT_BGRA;
+use crate::upload::{ingest_audio_throttled, AudioPacket, CpuFormat, UploadStore};
+
+static RUNTIME: OnceLock<Result<NDI, String>> = OnceLock::new();
+
+fn runtime() -> Result<&'static NDI, String> {
+    match RUNTIME.get_or_init(|| NDI::new().map_err(|error| error.to_string())) {
+        Ok(ndi) => Ok(ndi),
+        Err(error) => Err(error.clone()),
+    }
+}
+
+pub struct NdiReceiver {
+    stop: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl NdiReceiver {
+    pub fn start(
+        source_id: u64,
+        address: String,
+        uploads: Arc<Mutex<UploadStore>>,
+        frame_buffer_frames: u32,
+    ) -> Result<Self, String> {
+        let depth = frame_buffer_frames.clamp(1, 8);
+        let ndi = runtime()?;
+        let source = resolve_source(ndi, &address)?;
+        let options = ReceiverOptions::builder(source)
+            .color(ReceiverColorFormat::BGRX_BGRA)
+            .allow_video_fields(false)
+            .name("eiviz")
+            .build();
+        let receiver = Receiver::new(ndi, &options).map_err(|error| error.to_string())?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let join = thread::Builder::new()
+            .name(format!("eiviz-ndi-{source_id}"))
+            .spawn(move || {
+                {
+                    let mut store = uploads.lock().expect("uploads lock");
+                    store.ensure_playout(
+                        source_id,
+                        16,
+                        16,
+                        CpuFormat::from_abi(FMT_BGRA).expect("BGRA"),
+                        depth,
+                    );
+                }
+                while !stop_thread.load(Ordering::Relaxed) {
+                    match receiver.video().try_capture(Duration::from_millis(4)) {
+                        Ok(Some(frame)) => ingest_video(&uploads, source_id, depth, &frame),
+                        Ok(None) => {}
+                        Err(_) => {}
+                    }
+                    loop {
+                        match receiver.audio().try_capture(Duration::ZERO) {
+                            Ok(Some(audio)) => {
+                                ingest_audio_throttled(&uploads, source_id, to_audio(&audio));
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+            })
+            .map_err(|error| error.to_string())?;
+        Ok(Self {
+            stop,
+            join: Some(join),
+        })
+    }
+}
+
+impl Drop for NdiReceiver {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+pub struct NdiSender {
+    sender: Sender,
+}
+
+impl NdiSender {
+    pub fn start(name: &str) -> Result<Self, String> {
+        let ndi = runtime()?;
+        let options = SenderOptions::builder(name)
+            .clock_video(true)
+            .clock_audio(true)
+            .build();
+        let sender = Sender::new(ndi, &options).map_err(|error| error.to_string())?;
+        Ok(Self { sender })
+    }
+
+    pub fn pump(&mut self) -> Result<bool, String> {
+        match self.sender.connection_count(Duration::ZERO) {
+            Ok(count) => Ok(count > 0),
+            Err(_) => Ok(false),
+        }
+    }
+
+    pub fn send_video_uyvy(
+        &mut self,
+        width: u32,
+        height: u32,
+        stride: u32,
+        pts: i64,
+        pixels: &[u8],
+        fps_num: u32,
+        fps_den: u32,
+    ) -> Result<(), String> {
+        let packed = pack_uyvy(width, height, stride, pixels);
+        let mut frame = VideoFrame::builder()
+            .resolution(width.max(1) as i32, height.max(1) as i32)
+            .pixel_format(PixelFormat::UYVY)
+            .frame_rate(fps_num.max(1) as i32, fps_den.max(1) as i32)
+            .aspect_ratio(width as f32 / height.max(1) as f32)
+            .timestamp(pts)
+            .timecode(pts)
+            .build()
+            .map_err(|error| error.to_string())?;
+        frame
+            .replace_data(packed)
+            .map_err(|error| error.to_string())?;
+        self.sender.send_video(&frame);
+        Ok(())
+    }
+
+    pub fn send_audio(&mut self, audio: &AudioPacket) -> Result<(), String> {
+        let channels = audio.channels.max(1);
+        let samples = audio.samples_per_channel.max(1);
+        let floats: Vec<f32> = audio
+            .pcm_planar_f32
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+        if floats.is_empty() {
+            return Ok(());
+        }
+        let expected = channels as usize * samples as usize;
+        let data = if floats.len() == expected {
+            floats
+        } else {
+            let n = floats.len().min(expected);
+            let mut trimmed = vec![0.0f32; expected];
+            trimmed[..n].copy_from_slice(&floats[..n]);
+            trimmed
+        };
+        let frame = AudioFrame::builder()
+            .sample_rate(audio.sample_rate.max(1))
+            .channels(channels)
+            .samples(samples)
+            .timestamp(audio.timestamp)
+            .timecode(audio.timestamp)
+            .data(data)
+            .build()
+            .map_err(|error| error.to_string())?;
+        self.sender.send_audio(&frame);
+        Ok(())
+    }
+}
+
+pub fn discover_sources() -> Result<Vec<String>, String> {
+    let ndi = runtime()?;
+    let finder = Finder::new(ndi, &FinderOptions::builder().show_local_sources(true).build())
+        .map_err(|error| error.to_string())?;
+    let _ = finder.wait_for_sources(Duration::from_millis(400));
+    let sources = finder
+        .current_sources()
+        .or_else(|_| finder.find_sources(Duration::from_millis(200)))
+        .map_err(|error| error.to_string())?;
+    Ok(sources.into_iter().map(|source| source.to_string()).collect())
+}
+
+fn resolve_source(ndi: &NDI, query: &str) -> Result<Source, String> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return Err("NDI source name is empty".into());
+    }
+    let finder = Finder::new(ndi, &FinderOptions::builder().show_local_sources(true).build())
+        .map_err(|error| error.to_string())?;
+    let _ = finder.wait_for_sources(Duration::from_secs(2));
+    let sources = finder
+        .current_sources()
+        .or_else(|_| finder.find_sources(Duration::from_millis(500)))
+        .map_err(|error| error.to_string())?;
+    if let Some(source) = sources.iter().find(|source| source_key(source).eq_ignore_ascii_case(trimmed))
+    {
+        return Ok(source.clone());
+    }
+    if let Some(source) = sources.iter().find(|source| source.name.eq_ignore_ascii_case(trimmed)) {
+        return Ok(source.clone());
+    }
+    let matches: Vec<_> = sources
+        .iter()
+        .filter(|source| {
+            source_key(source).to_ascii_lowercase().contains(&trimmed.to_ascii_lowercase())
+                || source.name.to_ascii_lowercase().contains(&trimmed.to_ascii_lowercase())
+        })
+        .cloned()
+        .collect();
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().expect("len 1")),
+        0 => Err(format!("NDI source not found: {trimmed}")),
+        _ => Err(format!("NDI source name is ambiguous: {trimmed}")),
+    }
+}
+
+fn source_key(source: &Source) -> String {
+    source.to_string()
+}
+
+fn ingest_video(
+    uploads: &Mutex<UploadStore>,
+    source_id: u64,
+    depth: u32,
+    frame: &VideoFrame,
+) {
+    let width = frame.width().max(2) as u32;
+    let height = frame.height().max(2) as u32;
+    let pixel_format = frame.pixel_format();
+    let format = match pixel_format {
+        PixelFormat::UYVY => CpuFormat::Uyvy,
+        PixelFormat::RGBA | PixelFormat::RGBX => CpuFormat::Rgba,
+        _ => CpuFormat::Bgra,
+    };
+    let bpp = match format {
+        CpuFormat::Uyvy => 2usize,
+        _ => 4usize,
+    };
+    let stride = match frame.line_stride_or_size() {
+        LineStrideOrSize::LineStrideBytes(stride) if stride > 0 => stride as usize,
+        _ => width as usize * bpp,
+    };
+    let mut opaque = Vec::new();
+    let pixels = if matches!(pixel_format, PixelFormat::BGRX | PixelFormat::RGBX) {
+        opaque = frame.data().to_vec();
+        for chunk in opaque.chunks_exact_mut(4) {
+            if chunk.len() == 4 {
+                chunk[3] = 255;
+            }
+        }
+        opaque.as_slice()
+    } else {
+        frame.data()
+    };
+    let mut store = uploads.lock().expect("uploads lock");
+    store.ensure_playout(source_id, width, height, format, depth);
+    let _ = store.push_playout_cpu(source_id, pixels, stride, frame.timestamp());
+}
+
+fn to_audio(frame: &AudioFrame) -> AudioPacket {
+    let channels = frame.num_channels().max(1);
+    let samples = frame.num_samples().max(1);
+    let mut pcm = Vec::with_capacity(frame.data().len() * 4);
+    for sample in frame.data() {
+        pcm.extend_from_slice(&sample.to_le_bytes());
+    }
+    AudioPacket {
+        timestamp: frame.timestamp(),
+        sample_rate: frame.sample_rate().max(1),
+        channels,
+        samples_per_channel: samples,
+        pcm_planar_f32: pcm,
+    }
+}
+
+fn pack_uyvy(width: u32, height: u32, stride: u32, pixels: &[u8]) -> Vec<u8> {
+    let width = width.max(1);
+    let height = height.max(1);
+    let packed_stride = width.saturating_mul(2) as usize;
+    let src_stride = stride.max(packed_stride as u32) as usize;
+    let mut packed = vec![0u8; packed_stride * height as usize];
+    for y in 0..height as usize {
+        let src = y * src_stride;
+        let dst = y * packed_stride;
+        let end = src.saturating_add(packed_stride);
+        if end <= pixels.len() {
+            packed[dst..dst + packed_stride].copy_from_slice(&pixels[src..end]);
+        }
+    }
+    packed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pack_uyvy;
+
+    #[test]
+    fn pack_uyvy_strips_padded_stride() {
+        let width = 4u32;
+        let height = 2u32;
+        let stride = 16u32;
+        let mut src = vec![0u8; (stride * height) as usize];
+        src[0..8].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        src[16..24].copy_from_slice(&[9, 10, 11, 12, 13, 14, 15, 16]);
+        let packed = pack_uyvy(width, height, stride, &src);
+        assert_eq!(packed, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    }
+}

--- a/mixer/src/omt.rs
+++ b/mixer/src/omt.rs
@@ -6,9 +6,10 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use openmediatransport::{
-    Codec, DecodedAudioFrame, Discovery, FrameType, GpuVideoContext, MediaFrame, ReceiverConfig,
-    ReceiverSession, Sender, VideoTextureMeta,
+    Codec, DecodedAudioFrame, Discovery, FrameType, GpuVideoContext, MediaFrame, Quality,
+    ReceiverConfig, ReceiverSession, Sender, Tally, VideoTextureMeta,
 };
+use openmediatransport::protocol::metadata::{suggested_quality_xml, PREVIEW_OFF, PREVIEW_ON};
 
 use crate::abi::FMT_BGRA;
 use crate::device::GpuDevice;
@@ -25,6 +26,9 @@ pub fn omt_gpu_from_device(device: &GpuDevice) -> OmtGpu {
 
 pub struct OmtReceiver {
     stop: Arc<AtomicBool>,
+    want_full: Arc<AtomicBool>,
+    on_program: Arc<AtomicBool>,
+    on_preview: Arc<AtomicBool>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -46,7 +50,13 @@ impl OmtReceiver {
         };
         let session = connect_receiver(&address, config)?;
         let stop = Arc::new(AtomicBool::new(false));
+        let want_full = Arc::new(AtomicBool::new(true));
+        let on_program = Arc::new(AtomicBool::new(false));
+        let on_preview = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
+        let want_full_thread = Arc::clone(&want_full);
+        let on_program_thread = Arc::clone(&on_program);
+        let on_preview_thread = Arc::clone(&on_preview);
         let join = thread::Builder::new()
             .name(format!("eiviz-omt-{source_id}"))
             .spawn(move || {
@@ -59,7 +69,15 @@ impl OmtReceiver {
                     };
                     store.ensure_playout(source_id, 16, 16, format, depth);
                 }
+                let mut sent: Option<(bool, bool, bool)> = None;
                 while !stop_thread.load(Ordering::Relaxed) {
+                    apply_omt_save(
+                        &session,
+                        want_full_thread.load(Ordering::Relaxed),
+                        on_program_thread.load(Ordering::Relaxed),
+                        on_preview_thread.load(Ordering::Relaxed),
+                        &mut sent,
+                    );
                     if use_gpu {
                         if let Some(frame) = session.recv_video_gpu_timeout(Duration::from_millis(4))
                         {
@@ -113,8 +131,17 @@ impl OmtReceiver {
             .map_err(|error| error.to_string())?;
         Ok(Self {
             stop,
+            want_full,
+            on_program,
+            on_preview,
             join: Some(join),
         })
+    }
+
+    pub fn apply_save(&self, full: bool, on_program: bool, on_preview: bool) {
+        self.want_full.store(full, Ordering::Relaxed);
+        self.on_program.store(on_program, Ordering::Relaxed);
+        self.on_preview.store(on_preview, Ordering::Relaxed);
     }
 }
 
@@ -347,6 +374,30 @@ impl GpuSendSlot {
             busy: Arc::new(AtomicBool::new(false)),
         }
     }
+}
+
+fn apply_omt_save(
+    session: &ReceiverSession,
+    full: bool,
+    on_program: bool,
+    on_preview: bool,
+    sent: &mut Option<(bool, bool, bool)>,
+) {
+    let next = (full, on_program, on_preview);
+    if *sent == Some(next) {
+        return;
+    }
+    *sent = Some(next);
+    let _ = session.send_metadata(if full { PREVIEW_OFF } else { PREVIEW_ON });
+    let _ = session.send_metadata(suggested_quality_xml(if full {
+        Quality::High
+    } else {
+        Quality::Low
+    }));
+    let _ = session.set_tally(Tally::new(
+        i32::from(on_preview),
+        i32::from(on_program),
+    ));
 }
 
 pub fn discover_addresses() -> Result<Vec<String>, String> {

--- a/mixer/src/omt.rs
+++ b/mixer/src/omt.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use openmediatransport::{
     Codec, DecodedAudioFrame, Discovery, FrameType, GpuVideoContext, MediaFrame, Quality,
@@ -13,6 +13,7 @@ use openmediatransport::protocol::metadata::{suggested_quality_xml, PREVIEW_OFF,
 
 use crate::abi::FMT_BGRA;
 use crate::device::GpuDevice;
+use crate::save::debounce_want_full;
 use crate::upload::{ingest_audio_throttled, AudioPacket, CpuFormat, GpuVideoFrame, UploadStore};
 
 pub type OmtGpu = GpuVideoContext;
@@ -29,6 +30,7 @@ pub struct OmtReceiver {
     want_full: Arc<AtomicBool>,
     on_program: Arc<AtomicBool>,
     on_preview: Arc<AtomicBool>,
+    quality: Arc<AtomicU32>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -39,13 +41,16 @@ impl OmtReceiver {
         uploads: Arc<Mutex<UploadStore>>,
         gpu: Option<OmtGpu>,
         frame_buffer_frames: u32,
+        quality: u32,
     ) -> Result<Self, String> {
         let depth = frame_buffer_frames.clamp(1, 8);
         let use_gpu = gpu.is_some();
+        let quality = quality_from_abi(quality);
         let config = ReceiverConfig {
             frame_types: FrameType::VIDEO | FrameType::AUDIO,
             connect_timeout: Duration::from_secs(5),
             gpu: gpu.clone(),
+            quality,
             ..ReceiverConfig::default()
         };
         let session = connect_receiver(&address, config)?;
@@ -53,10 +58,12 @@ impl OmtReceiver {
         let want_full = Arc::new(AtomicBool::new(true));
         let on_program = Arc::new(AtomicBool::new(false));
         let on_preview = Arc::new(AtomicBool::new(false));
+        let quality_atom = Arc::new(AtomicU32::new(quality_to_abi(quality)));
         let stop_thread = Arc::clone(&stop);
         let want_full_thread = Arc::clone(&want_full);
         let on_program_thread = Arc::clone(&on_program);
         let on_preview_thread = Arc::clone(&on_preview);
+        let quality_thread = Arc::clone(&quality_atom);
         let join = thread::Builder::new()
             .name(format!("eiviz-omt-{source_id}"))
             .spawn(move || {
@@ -69,13 +76,19 @@ impl OmtReceiver {
                     };
                     store.ensure_playout(source_id, 16, 16, format, depth);
                 }
-                let mut sent: Option<(bool, bool, bool)> = None;
+                let mut sent: Option<(bool, bool, bool, u32)> = None;
+                let mut drop_full_at: Option<Instant> = None;
                 while !stop_thread.load(Ordering::Relaxed) {
+                    let full = debounce_want_full(
+                        want_full_thread.load(Ordering::Relaxed),
+                        &mut drop_full_at,
+                    );
                     apply_omt_save(
                         &session,
-                        want_full_thread.load(Ordering::Relaxed),
+                        full,
                         on_program_thread.load(Ordering::Relaxed),
                         on_preview_thread.load(Ordering::Relaxed),
+                        quality_from_abi(quality_thread.load(Ordering::Relaxed)),
                         &mut sent,
                     );
                     if use_gpu {
@@ -134,6 +147,7 @@ impl OmtReceiver {
             want_full,
             on_program,
             on_preview,
+            quality: quality_atom,
             join: Some(join),
         })
     }
@@ -142,6 +156,11 @@ impl OmtReceiver {
         self.want_full.store(full, Ordering::Relaxed);
         self.on_program.store(on_program, Ordering::Relaxed);
         self.on_preview.store(on_preview, Ordering::Relaxed);
+    }
+
+    pub fn set_quality(&self, quality: u32) {
+        self.quality
+            .store(quality_to_abi(quality_from_abi(quality)), Ordering::Relaxed);
     }
 }
 
@@ -376,24 +395,41 @@ impl GpuSendSlot {
     }
 }
 
+fn quality_from_abi(value: u32) -> Quality {
+    match value {
+        1 => Quality::Low,
+        50 => Quality::Medium,
+        100 => Quality::High,
+        _ => Quality::Default,
+    }
+}
+
+fn quality_to_abi(quality: Quality) -> u32 {
+    match quality {
+        Quality::Low => 1,
+        Quality::Medium => 50,
+        Quality::High => 100,
+        Quality::Default => 0,
+    }
+}
+
+/// libomtnet matches Preview and Quality as exact tokens. A combined
+/// `<OMTSettings Preview="…" Quality="…" />` is ignored and Preview never turns on.
 fn apply_omt_save(
     session: &ReceiverSession,
     full: bool,
     on_program: bool,
     on_preview: bool,
-    sent: &mut Option<(bool, bool, bool)>,
+    quality: Quality,
+    sent: &mut Option<(bool, bool, bool, u32)>,
 ) {
-    let next = (full, on_program, on_preview);
+    let next = (full, on_program, on_preview, quality_to_abi(quality));
     if *sent == Some(next) {
         return;
     }
     *sent = Some(next);
     let _ = session.send_metadata(if full { PREVIEW_OFF } else { PREVIEW_ON });
-    let _ = session.send_metadata(suggested_quality_xml(if full {
-        Quality::High
-    } else {
-        Quality::Low
-    }));
+    let _ = session.send_metadata(suggested_quality_xml(quality));
     let _ = session.set_tally(Tally::new(
         i32::from(on_preview),
         i32::from(on_program),
@@ -498,5 +534,25 @@ fn to_audio(frame: DecodedAudioFrame) -> AudioPacket {
         channels: frame.channels,
         samples_per_channel: samples,
         pcm_planar_f32: frame.pcm_planar_f32.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openmediatransport::protocol::metadata::{suggested_quality_xml, PREVIEW_OFF, PREVIEW_ON};
+    use openmediatransport::Quality;
+
+    #[test]
+    fn preview_and_quality_are_exact_tokens() {
+        assert_eq!(PREVIEW_ON, r#"<OMTSettings Preview="true" />"#);
+        assert_eq!(PREVIEW_OFF, r#"<OMTSettings Preview="false" />"#);
+        assert_eq!(
+            suggested_quality_xml(Quality::Default),
+            r#"<OMTSettings Quality="Default" />"#
+        );
+        assert_eq!(
+            suggested_quality_xml(Quality::Medium),
+            r#"<OMTSettings Quality="Medium" />"#
+        );
     }
 }

--- a/mixer/src/present.rs
+++ b/mixer/src/present.rs
@@ -103,6 +103,10 @@ impl Presenters {
             .clamp(1, 8)
     }
 
+    pub fn attached_monitor_sources(&self) -> Vec<u64> {
+        self.monitor_sources.values().copied().collect()
+    }
+
     pub fn attached_monitor_sources_due(&self, frame_i: u64) -> Vec<u64> {
         self.monitor_sources
             .iter()

--- a/mixer/src/save.rs
+++ b/mixer/src/save.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::abi::{
     is_scene, mixing_unit_from_source, OverlayDesc, UnitState, SAVE_ALWAYS_FULL, SAVE_ALWAYS_LOW,
@@ -41,6 +42,20 @@ impl Default for LiveSave {
             flags: 0,
         }
     }
+}
+
+/// Hold full quality this long after the source leaves Preview/Program so TAKE
+/// and T-bar flicker do not thrash OMT metadata or recreate the NDI receiver.
+pub const DROP_FULL_HOLD: Duration = Duration::from_millis(280);
+
+/// Raise immediately; drop to low only after `DROP_FULL_HOLD` of continuous unused.
+pub fn debounce_want_full(want: bool, drop_at: &mut Option<Instant>) -> bool {
+    if want {
+        *drop_at = None;
+        return true;
+    }
+    let started = drop_at.get_or_insert_with(Instant::now);
+    Instant::now().saturating_duration_since(*started) < DROP_FULL_HOLD
 }
 
 pub fn want_full(save: LiveSave, roles: SourceRoles) -> bool {
@@ -226,5 +241,16 @@ mod tests {
         assert!(want_full(not_pvw, prv));
         assert!(!want_full(not_pvw, mv));
         assert!(want_full(not_pvw_mv, mv));
+    }
+
+    #[test]
+    fn debounce_raises_immediately_and_holds_drop() {
+        let mut drop_at = None;
+        assert!(debounce_want_full(true, &mut drop_at));
+        assert!(debounce_want_full(false, &mut drop_at));
+        std::thread::sleep(DROP_FULL_HOLD + Duration::from_millis(40));
+        assert!(!debounce_want_full(false, &mut drop_at));
+        assert!(debounce_want_full(true, &mut drop_at));
+        assert!(drop_at.is_none());
     }
 }

--- a/mixer/src/save.rs
+++ b/mixer/src/save.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::abi::{
+    is_scene, mixing_unit_from_source, OverlayDesc, UnitState, SAVE_ALWAYS_FULL, SAVE_ALWAYS_LOW,
+    SAVE_FLAG_MULTIVIEW, SAVE_NOT_ON_PREVIEW_OR_PROGRAM, SAVE_NOT_ON_PROGRAM, SRC_KIND_INPUT,
+    SRC_KIND_MU_MULTIVIEW, SRC_KIND_SCENE,
+};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SourceRoles {
+    pub on_program: bool,
+    pub on_preview: bool,
+    pub on_multiview: bool,
+}
+
+impl SourceRoles {
+    fn mark_program(&mut self) {
+        self.on_program = true;
+    }
+
+    fn mark_preview(&mut self) {
+        self.on_preview = true;
+    }
+
+    fn mark_multiview(&mut self) {
+        self.on_multiview = true;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct LiveSave {
+    pub mode: u32,
+    pub flags: u32,
+}
+
+impl Default for LiveSave {
+    fn default() -> Self {
+        Self {
+            mode: SAVE_NOT_ON_PREVIEW_OR_PROGRAM,
+            flags: 0,
+        }
+    }
+}
+
+pub fn want_full(save: LiveSave, roles: SourceRoles) -> bool {
+    let keep_mv = save.flags & SAVE_FLAG_MULTIVIEW != 0 && roles.on_multiview;
+    match save.mode {
+        SAVE_ALWAYS_LOW => false,
+        SAVE_ALWAYS_FULL => true,
+        SAVE_NOT_ON_PROGRAM => roles.on_program || keep_mv,
+        SAVE_NOT_ON_PREVIEW_OR_PROGRAM => {
+            roles.on_program || roles.on_preview || keep_mv
+        }
+        _ => roles.on_program || roles.on_preview || keep_mv,
+    }
+}
+
+pub fn collect_source_roles(
+    scene_specs: &[(u64, u32, u32, Arc<[OverlayDesc]>)],
+    snapshot: &[(u64, u32, u32, u32, u32, UnitState)],
+    monitor_sources: &[u64],
+    outputs: &[(u32, u64)],
+) -> HashMap<u64, SourceRoles> {
+    let spec_map: HashMap<u64, &[OverlayDesc]> =
+        scene_specs.iter().map(|spec| (spec.0, spec.3.as_ref())).collect();
+    let mut roles = HashMap::<u64, SourceRoles>::new();
+    for (_, _, _, _, _, state) in snapshot {
+        add(state.program_source, Role::Program, &spec_map, &mut roles);
+        add(state.preview_source, Role::Preview, &spec_map, &mut roles);
+        if state.mix > 0.001 {
+            add(state.preview_source, Role::Program, &spec_map, &mut roles);
+        }
+        for overlay in state.overlays.iter().take(state.overlay_count as usize) {
+            add(overlay.source_id, Role::Program, &spec_map, &mut roles);
+        }
+        for slot in state.mv_slots.iter().take(state.mv_slot_count as usize) {
+            add(*slot, Role::Multiview, &spec_map, &mut roles);
+        }
+    }
+    for id in monitor_sources {
+        add(*id, Role::Preview, &spec_map, &mut roles);
+    }
+    for &(kind, source_id) in outputs {
+        match kind {
+            SRC_KIND_INPUT => add(source_id, Role::Program, &spec_map, &mut roles),
+            SRC_KIND_SCENE | SRC_KIND_MU_MULTIVIEW => {
+                add(source_id, Role::Multiview, &spec_map, &mut roles)
+            }
+            _ => {}
+        }
+    }
+    roles
+}
+
+#[derive(Clone, Copy)]
+enum Role {
+    Program,
+    Preview,
+    Multiview,
+}
+
+fn add(
+    id: u64,
+    role: Role,
+    spec_map: &HashMap<u64, &[OverlayDesc]>,
+    roles: &mut HashMap<u64, SourceRoles>,
+) {
+    if crate::abi::is_multiview(id) {
+        return;
+    }
+    if is_scene(id) {
+        if let Some(layers) = spec_map.get(&id) {
+            for layer in *layers {
+                add(layer.source_id, role, spec_map, roles);
+            }
+        }
+        return;
+    }
+    if mixing_unit_from_source(id).is_some() {
+        return;
+    }
+    if id == 0 {
+        return;
+    }
+    let entry = roles.entry(id).or_default();
+    match role {
+        Role::Program => entry.mark_program(),
+        Role::Preview => entry.mark_preview(),
+        Role::Multiview => entry.mark_multiview(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abi::{SCENE_BASE, SRC_BLUE, SRC_COLOR};
+
+    fn scene(id: u64, layers: &[u64]) -> (u64, u32, u32, Arc<[OverlayDesc]>) {
+        let overlays: Arc<[OverlayDesc]> = layers
+            .iter()
+            .map(|source_id| OverlayDesc {
+                source_id: *source_id,
+                opacity: 1.0,
+                ..OverlayDesc::default()
+            })
+            .collect();
+        (SCENE_BASE | id, 1920, 1080, overlays)
+    }
+
+    fn unit(program: u64, preview: u64, mix: f32) -> (u64, u32, u32, u32, u32, UnitState) {
+        (
+            1,
+            1920,
+            1080,
+            60_000,
+            1_001,
+            UnitState {
+                program_source: program,
+                preview_source: preview,
+                mix,
+                ..UnitState::default()
+            },
+        )
+    }
+
+    #[test]
+    fn nested_scene_on_program_counts_inputs() {
+        let specs = [scene(1, &[SRC_COLOR, 20])];
+        let snapshot = [unit(SCENE_BASE | 1, SRC_BLUE, 0.0)];
+        let roles = collect_source_roles(&specs, &snapshot, &[], &[]);
+        assert!(roles.get(&20).is_some_and(|item| item.on_program));
+        assert!(!roles.get(&20).is_some_and(|item| item.on_preview));
+        assert!(roles.get(&SRC_BLUE).is_some_and(|item| item.on_preview));
+        assert!(!roles.get(&SRC_BLUE).is_some_and(|item| item.on_program));
+    }
+
+    #[test]
+    fn tbar_mix_puts_preview_on_program() {
+        let snapshot = [unit(SRC_COLOR, 20, 0.4)];
+        let roles = collect_source_roles(&[], &snapshot, &[], &[]);
+        assert!(roles.get(&20).is_some_and(|item| item.on_program && item.on_preview));
+    }
+
+    #[test]
+    fn save_modes_match_issue_options() {
+        let unused = SourceRoles::default();
+        let pgm = SourceRoles {
+            on_program: true,
+            ..SourceRoles::default()
+        };
+        let prv = SourceRoles {
+            on_preview: true,
+            ..SourceRoles::default()
+        };
+        let mv = SourceRoles {
+            on_multiview: true,
+            ..SourceRoles::default()
+        };
+        let always_low = LiveSave {
+            mode: SAVE_ALWAYS_LOW,
+            flags: 0,
+        };
+        let not_pgm = LiveSave {
+            mode: SAVE_NOT_ON_PROGRAM,
+            flags: 0,
+        };
+        let not_pvw = LiveSave {
+            mode: SAVE_NOT_ON_PREVIEW_OR_PROGRAM,
+            flags: 0,
+        };
+        let always_full = LiveSave {
+            mode: SAVE_ALWAYS_FULL,
+            flags: 0,
+        };
+        let not_pvw_mv = LiveSave {
+            mode: SAVE_NOT_ON_PREVIEW_OR_PROGRAM,
+            flags: SAVE_FLAG_MULTIVIEW,
+        };
+        assert!(!want_full(always_low, pgm));
+        assert!(want_full(always_full, unused));
+        assert!(!want_full(not_pgm, unused));
+        assert!(!want_full(not_pgm, prv));
+        assert!(want_full(not_pgm, pgm));
+        assert!(!want_full(not_pvw, unused));
+        assert!(want_full(not_pvw, prv));
+        assert!(!want_full(not_pvw, mv));
+        assert!(want_full(not_pvw_mv, mv));
+    }
+}

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -74,7 +74,7 @@ fn dx12_compose_omt_and_program_out() {
     let url = format!("omt://127.0.0.1:{}", sender.port());
     let address = CString::new(url).unwrap();
     unsafe {
-        assert_eq!(mixer_omt_connect(20, address.as_ptr(), 0, 1), OK);
+        assert_eq!(mixer_omt_connect(20, address.as_ptr(), 0, 1, 0), OK);
         assert_eq!(
             mixer_omt_start_send(1, CString::new("eiviz-test-pgm").unwrap().as_ptr()),
             OK
@@ -147,7 +147,7 @@ fn dx12_omt_gpu_in_and_out() {
     let url = format!("omt://127.0.0.1:{}", sender.port());
     let address = CString::new(url).unwrap();
     unsafe {
-        assert_eq!(mixer_omt_connect(21, address.as_ptr(), 1, 3), OK);
+        assert_eq!(mixer_omt_connect(21, address.as_ptr(), 1, 3, 0), OK);
         assert_eq!(
             mixer_output_add(
                 201,

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 use eiviz_mixer::{
     mixer_audio_bus_count, mixer_create, mixer_create_unit, mixer_define_scene, mixer_destroy,
     mixer_ndi_discover, mixer_omt_connect, mixer_omt_start_send, mixer_output_add, mixer_output_remove,
-    mixer_ping, mixer_unit_acquire_frame, mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state,
+    mixer_ping, mixer_set_live_save, mixer_unit_acquire_frame, mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state,
     mixer_unit_release_frame, mixer_unit_set_state, mixer_video_start, OverlayDesc, Rect, UnitState,
-    ERR_INVALID_ARGUMENT, ERR_IO, OK, OUT_DECKLINK, OUT_NDI, OUT_OMT, SCENE_BASE, SRC_BARS, SRC_BLUE,
+    ERR_INVALID_ARGUMENT, ERR_IO, ERR_NOT_CREATED, OK, OUT_DECKLINK, OUT_NDI, OUT_OMT, SCENE_BASE, SRC_BARS, SRC_BLUE,
     SRC_COLOR, SRC_KIND_MU_PROGRAM,
 };
 use openmediatransport::{Codec, FrameType, MediaFrame, Sender};
@@ -16,6 +16,8 @@ use openmediatransport::{Codec, FrameType, MediaFrame, Sender};
 fn ping_and_invalid_clock() {
     assert_eq!(mixer_ping(), 0x4549_5649);
     assert_eq!(mixer_create(0, 60_000, 0), ERR_INVALID_ARGUMENT);
+    mixer_destroy();
+    assert_eq!(mixer_set_live_save(1, 2, 0), ERR_NOT_CREATED);
 }
 
 #[test]

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 
 use eiviz_mixer::{
     mixer_audio_bus_count, mixer_create, mixer_create_unit, mixer_define_scene, mixer_destroy,
-    mixer_omt_connect, mixer_omt_start_send, mixer_output_add, mixer_ping, mixer_unit_acquire_frame,
-    mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state, mixer_unit_release_frame,
-    mixer_unit_set_state, mixer_video_start, OverlayDesc, Rect, UnitState, ERR_INVALID_ARGUMENT,
-    ERR_IO, OK, OUT_DECKLINK, OUT_NDI, OUT_OMT, SCENE_BASE, SRC_BARS, SRC_BLUE, SRC_COLOR,
-    SRC_KIND_MU_PROGRAM,
+    mixer_ndi_discover, mixer_omt_connect, mixer_omt_start_send, mixer_output_add, mixer_output_remove,
+    mixer_ping, mixer_unit_acquire_frame, mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state,
+    mixer_unit_release_frame, mixer_unit_set_state, mixer_video_start, OverlayDesc, Rect, UnitState,
+    ERR_INVALID_ARGUMENT, ERR_IO, OK, OUT_DECKLINK, OUT_NDI, OUT_OMT, SCENE_BASE, SRC_BARS, SRC_BLUE,
+    SRC_COLOR, SRC_KIND_MU_PROGRAM,
 };
 use openmediatransport::{Codec, FrameType, MediaFrame, Sender};
 
@@ -311,14 +311,18 @@ fn scene_compose_overlay_after_mix_multiview_and_tbar_take() {
             mixer_output_add(
                 99,
                 OUT_NDI,
-                CString::new("ndi-unlinked").unwrap().as_ptr(),
+                CString::new("eiviz-ndi-test").unwrap().as_ptr(),
                 SRC_KIND_MU_PROGRAM,
                 0,
                 1,
                 0
             ),
-            ERR_IO
+            OK
         );
+        assert_eq!(mixer_output_remove(99), OK);
+        let mut ndi_names = vec![0u8; 4096];
+        let discovered = mixer_ndi_discover(ndi_names.as_mut_ptr(), ndi_names.len());
+        assert!(discovered >= 0);
         assert_eq!(
             mixer_output_add(
                 98,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NDI® receive and send are always compiled in, using grafton-ndi 1.0 with no mixer Cargo feature.

## Mixer
- New `mixer/src/ndi.rs`: Finder discovery, CPU BGRA receive into the existing playout FIFO, and UYVY send from the existing pack/readback path.
- `mixer_ndi_connect` / `mixer_ndi_discover` ABI next to the OMT equivalents.
- `mixer_output_add(OUT_NDI)` creates an NDI sender (GPU encode stays OMT-only). DeckLink remains unlinked.
- `Processing.NDI.Lib.x64.dll` is copied next to the mixer DLL at build time.

## Host
- Input dialog can discover and connect NDI sources (frame buffer 1–8, no GPU decode).
- Settings can add NDI outputs; they start on boot like OMT.
- Release zip includes the NDI runtime DLL.

## CI
- Windows jobs install LLVM (bindgen) and NDI SDK 6, then run the existing `cargo test --locked` and `dotnet build` / publish.

NDI SDK remains under Vizrt terms; grafton-ndi is Apache-2.0. See THIRD_PARTY_NOTICES.md.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04df4-9561-7ae8-a549-efac8eec7b82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04df4-9561-7ae8-a549-efac8eec7b82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

