### PR TITLE
Keep session-load switching live and attach local inputs sooner

### DIFF
--- a/host/App.xaml.cs
+++ b/host/App.xaml.cs
@@ -103,64 +103,71 @@ public partial class App : Application
     private void AttachInputs()
     {
         foreach (var input in Session.Inputs)
+            AttachInput(input, network: false);
+        foreach (var input in Session.Inputs)
+            AttachInput(input, network: true);
+    }
+
+    private void AttachInput(InputEntry input, bool network)
+    {
+        try
         {
-            try
+            switch (input.Kind)
             {
-                switch (input.Kind)
-                {
-                    case InputKind.Color:
-                    case InputKind.Bars:
-                        if (input.Id > MixerNative.Blue)
-                        {
-                            MixerNative.ThrowIfFailed(
-                                MixerNative.DefineGenerator(
-                                    input.Id,
-                                    input.Kind == InputKind.Bars ? MixerNative.GenBars : MixerNative.GenSolid,
-                                    input.ColorR,
-                                    input.ColorG,
-                                    input.ColorB,
-                                    1,
-                                    input.Scroll ? 1u : 0u),
-                                "Define colour generator");
-                        }
-                        MixerNative.GeneratorSetTone(input.Id, input.ToneHz, input.ToneLevelDbfs);
-                        break;
-                    case InputKind.Still when !string.IsNullOrWhiteSpace(input.PathOrAddress):
-                        Commands.TryEnqueue(new LoadStillCommand(input.Id, input.PathOrAddress));
-                        break;
-                    case InputKind.Video when !string.IsNullOrWhiteSpace(input.PathOrAddress):
-                        Commands.TryEnqueue(new StartVideoCommand(
-                            input.Id,
-                            input.PathOrAddress,
-                            input.VideoLoop,
-                            input.VideoStartsPlaying));
-                        break;
-                    case InputKind.Omt when !string.IsNullOrWhiteSpace(input.PathOrAddress):
-                        Commands.TryEnqueue(new ConnectOmtCommand(
-                            input.Id,
-                            input.PathOrAddress,
-                            input.UseGpu,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
-                            input.BandwidthSave,
-                            input.KeepFullOnMultiview,
-                            input.OmtQuality));
-                        break;
-                    case InputKind.Ndi when !string.IsNullOrWhiteSpace(input.PathOrAddress):
-                        Commands.TryEnqueue(new ConnectNdiCommand(
-                            input.Id,
-                            input.PathOrAddress,
-                            input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
-                            input.NdiBandwidth));
-                        break;
-                    case InputKind.Uvc when !string.IsNullOrWhiteSpace(input.PathOrAddress):
-                        Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress, input.CaptureWidth, input.CaptureHeight, input.CaptureFpsNum, input.CaptureFpsDen));
-                        break;
-                }
+                case InputKind.Color:
+                case InputKind.Bars:
+                    if (network)
+                        return;
+                    if (input.Id > MixerNative.Blue)
+                    {
+                        MixerNative.ThrowIfFailed(
+                            MixerNative.DefineGenerator(
+                                input.Id,
+                                input.Kind == InputKind.Bars ? MixerNative.GenBars : MixerNative.GenSolid,
+                                input.ColorR,
+                                input.ColorG,
+                                input.ColorB,
+                                1,
+                                input.Scroll ? 1u : 0u),
+                            "Define colour generator");
+                    }
+                    MixerNative.GeneratorSetTone(input.Id, input.ToneHz, input.ToneLevelDbfs);
+                    break;
+                case InputKind.Still when !network && !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                    Commands.TryEnqueue(new LoadStillCommand(input.Id, input.PathOrAddress));
+                    break;
+                case InputKind.Video when !network && !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                    Commands.TryEnqueue(new StartVideoCommand(
+                        input.Id,
+                        input.PathOrAddress,
+                        input.VideoLoop,
+                        input.VideoStartsPlaying));
+                    break;
+                case InputKind.Uvc when !network && !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                    Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress, input.CaptureWidth, input.CaptureHeight, input.CaptureFpsNum, input.CaptureFpsDen));
+                    break;
+                case InputKind.Omt when network && !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                    Commands.TryEnqueue(new ConnectOmtCommand(
+                        input.Id,
+                        input.PathOrAddress,
+                        input.UseGpu,
+                        input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+                        input.BandwidthSave,
+                        input.KeepFullOnMultiview,
+                        input.OmtQuality));
+                    break;
+                case InputKind.Ndi when network && !string.IsNullOrWhiteSpace(input.PathOrAddress):
+                    Commands.TryEnqueue(new ConnectNdiCommand(
+                        input.Id,
+                        input.PathOrAddress,
+                        input.FrameBufferFrames == 0 ? 1 : Math.Clamp(input.FrameBufferFrames, 1u, 8u),
+                        input.NdiBandwidth));
+                    break;
             }
-            catch (Exception ex)
-            {
-                HostLog.WriteException(ex);
-            }
+        }
+        catch (Exception ex)
+        {
+            HostLog.WriteException(ex);
         }
     }
 

--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -58,7 +58,15 @@ internal sealed class CommandQueue : IAsyncDisposable
             TaskScheduler.Default);
     }
 
-    public bool TryEnqueue(MixerCommand command) => _commands.Writer.TryWrite(command);
+    public bool TryEnqueue(MixerCommand command)
+    {
+        if (IsDeferredIo(command))
+            return _commands.Writer.TryWrite(command);
+        return ApplyHandled(command);
+    }
+
+    private static bool IsDeferredIo(MixerCommand command) =>
+        command is ConnectOmtCommand or ConnectNdiCommand or LoadStillCommand or StartVideoCommand or StartUvcCommand;
 
     public void DefineSceneNow(SceneEntry scene, uint width, uint height)
     {
@@ -257,135 +265,160 @@ internal sealed class CommandQueue : IAsyncDisposable
 
     private async Task ConsumeAsync(CancellationToken token)
     {
-        await foreach (var command in _commands.Reader.ReadAllAsync(token))
+        var inflight = new List<Task>();
+        try
         {
-            try
+            await foreach (var command in _commands.Reader.ReadAllAsync(token))
             {
-                switch (command)
+                var captured = command;
+                inflight.Add(Task.Run(() => ApplyHandled(captured)));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        if (inflight.Count > 0)
+        {
+            try { await Task.WhenAll(inflight).ConfigureAwait(false); }
+            catch (Exception ex) { HostLog.WriteException(ex); }
+        }
+    }
+
+    private bool ApplyHandled(MixerCommand command)
+    {
+        try
+        {
+            Apply(command);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            HostLog.WriteException(ex);
+            if (command is LoadStillCommand or StartVideoCommand)
+                ReportUserError(ex.Message, Loc.T("msg.addInput"));
+            return false;
+        }
+    }
+
+    private static void Apply(MixerCommand command)
+    {
+        switch (command)
+        {
+            case SetMixCommand setMix:
+                ApplyMix(setMix.UnitId, setMix.Value, setMix.Preset);
+                break;
+            case CutCommand cut:
+                MixerNative.ThrowIfFailed(MixerNative.Cut(cut.UnitId, cut.Swap ? 1u : 0u, MixerNative.IncomingPreview), "CUT");
+                break;
+            case AutoCommand auto:
+                ApplyAuto(auto);
+                break;
+            case PreviewSceneCommand preview:
+                ApplyPreview(preview.UnitId, preview.SceneGpuId);
+                break;
+            case PushUnitStateCommand push:
+                ApplyState(push.UnitId, push.State);
+                break;
+            case PatchAuxCommand patch:
+                PatchAux(patch.UnitId, patch.Unit);
+                break;
+            case DefineSceneCommand define:
+                PushScene(define.Scene, define.Width, define.Height);
+                break;
+            case DestroySceneCommand destroy:
+                MixerNative.DestroyScene(destroy.GpuId);
+                break;
+            case ConnectOmtCommand connect:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.ConnectOmt(
+                        connect.SourceId,
+                        connect.Address,
+                        connect.UseGpu ? 1u : 0u,
+                        Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
+                        (uint)connect.Quality),
+                    "OMT connect");
+                MixerNative.ThrowIfFailed(
+                    MixerNative.SetLiveSave(
+                        connect.SourceId,
+                        (uint)connect.SaveMode,
+                        connect.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
+                    "OMT bandwidth save");
+                break;
+            case ConnectNdiCommand connect:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.ConnectNdi(
+                        connect.SourceId,
+                        connect.Address,
+                        Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
+                        connect.Bandwidth == NdiBandwidth.Lowest ? 1u : 0u),
+                    "NDI connect");
+                break;
+            case LiveSaveCommand save:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.SetLiveSave(
+                        save.SourceId,
+                        (uint)save.SaveMode,
+                        save.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
+                    "Bandwidth save");
+                if (save.OmtQuality is { } quality)
                 {
-                    case SetMixCommand setMix:
-                        ApplyMix(setMix.UnitId, setMix.Value, setMix.Preset);
-                        break;
-                    case CutCommand cut:
-                        MixerNative.ThrowIfFailed(MixerNative.Cut(cut.UnitId, cut.Swap ? 1u : 0u, MixerNative.IncomingPreview), "CUT");
-                        break;
-                    case AutoCommand auto:
-                        ApplyAuto(auto);
-                        break;
-                    case PreviewSceneCommand preview:
-                        ApplyPreview(preview.UnitId, preview.SceneGpuId);
-                        break;
-                    case PushUnitStateCommand push:
-                        ApplyState(push.UnitId, push.State);
-                        break;
-                    case PatchAuxCommand patch:
-                        PatchAux(patch.UnitId, patch.Unit);
-                        break;
-                    case DefineSceneCommand define:
-                        PushScene(define.Scene, define.Width, define.Height);
-                        break;
-                    case DestroySceneCommand destroy:
-                        MixerNative.DestroyScene(destroy.GpuId);
-                        break;
-                    case ConnectOmtCommand connect:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.ConnectOmt(
-                                connect.SourceId,
-                                connect.Address,
-                                connect.UseGpu ? 1u : 0u,
-                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
-                                (uint)connect.Quality),
-                            "OMT connect");
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.SetLiveSave(
-                                connect.SourceId,
-                                (uint)connect.SaveMode,
-                                connect.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
-                            "OMT bandwidth save");
-                        break;
-                    case ConnectNdiCommand connect:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.ConnectNdi(
-                                connect.SourceId,
-                                connect.Address,
-                                Math.Clamp(connect.FrameBufferFrames, 1u, 8u),
-                                connect.Bandwidth == NdiBandwidth.Lowest ? 1u : 0u),
-                            "NDI connect");
-                        break;
-                    case LiveSaveCommand save:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.SetLiveSave(
-                                save.SourceId,
-                                (uint)save.SaveMode,
-                                save.KeepFullOnMultiview ? MixerNative.SaveFlagMultiview : 0u),
-                            "Bandwidth save");
-                        if (save.OmtQuality is { } quality)
-                        {
-                            MixerNative.ThrowIfFailed(
-                                MixerNative.SetOmtQuality(save.SourceId, (uint)quality),
-                                "OMT quality");
-                        }
-                        break;
-                    case LoadStillCommand still:
-                        if (!File.Exists(still.Path))
-                            throw new InvalidOperationException(Loc.MissingFile("Still load"));
-                        MixerNative.ThrowIfFailed(MixerNative.LoadStill(still.SourceId, still.Path), "Still load");
-                        break;
-                    case StartVideoCommand video:
-                        if (!File.Exists(video.Path))
-                            throw new InvalidOperationException(Loc.MissingFile("Video start"));
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.VideoStart(video.SourceId, video.Path, 0, MixerNative.VideoFormat, 0, 0, 0, 0),
-                            "Video start");
-                        MixerNative.VideoSetLoop(video.SourceId, video.Loop ? 1u : 0u);
-                        MixerNative.VideoSetPlaying(video.SourceId, video.Playing ? 1u : 0u);
-                        break;
-                    case StartUvcCommand uvc:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.VideoStart(uvc.SourceId, uvc.SymbolicLink, 1, MixerNative.VideoFormat, uvc.Width, uvc.Height, uvc.FpsNum, uvc.FpsDen),
-                            "UVC start");
-                        break;
-                    case AddOutputCommand add:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.OutputAdd(
-                                add.Output.Id,
-                                (uint)add.Output.Transport,
-                                add.Output.Name,
-                                (uint)add.Output.SourceKind,
-                                add.Output.SourceId,
-                                add.Output.UnitId,
-                                add.Output.UseGpu ? 1u : 0u),
-                            "Add output");
-                        break;
-                    case RemoveOutputCommand remove:
-                        MixerNative.OutputRemove(remove.OutputId);
-                        break;
-                    case DefineGeneratorCommand generator:
-                        MixerNative.ThrowIfFailed(
-                            MixerNative.DefineGenerator(
-                                generator.SourceId,
-                                generator.Kind,
-                                generator.R,
-                                generator.G,
-                                generator.B,
-                                1,
-                                generator.Scroll ? 1u : 0u),
-                            "Define colour generator");
-                        MixerNative.GeneratorSetTone(generator.SourceId, generator.ToneHz, generator.ToneLevelDbfs);
-                        break;
-                    case DropSourceCommand drop:
-                        MixerNative.DestroySource(drop.SourceId);
-                        break;
-                    default:
-                        throw new InvalidOperationException("Unknown command.");
+                    MixerNative.ThrowIfFailed(
+                        MixerNative.SetOmtQuality(save.SourceId, (uint)quality),
+                        "OMT quality");
                 }
-            }
-            catch (Exception ex)
-            {
-                HostLog.WriteException(ex);
-                if (command is LoadStillCommand or StartVideoCommand)
-                    ReportUserError(ex.Message, Loc.T("msg.addInput"));
-            }
+                break;
+            case LoadStillCommand still:
+                if (!File.Exists(still.Path))
+                    throw new InvalidOperationException(Loc.MissingFile("Still load"));
+                MixerNative.ThrowIfFailed(MixerNative.LoadStill(still.SourceId, still.Path), "Still load");
+                break;
+            case StartVideoCommand video:
+                if (!File.Exists(video.Path))
+                    throw new InvalidOperationException(Loc.MissingFile("Video start"));
+                MixerNative.ThrowIfFailed(
+                    MixerNative.VideoStart(video.SourceId, video.Path, 0, MixerNative.VideoFormat, 0, 0, 0, 0),
+                    "Video start");
+                MixerNative.VideoSetLoop(video.SourceId, video.Loop ? 1u : 0u);
+                MixerNative.VideoSetPlaying(video.SourceId, video.Playing ? 1u : 0u);
+                break;
+            case StartUvcCommand uvc:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.VideoStart(uvc.SourceId, uvc.SymbolicLink, 1, MixerNative.VideoFormat, uvc.Width, uvc.Height, uvc.FpsNum, uvc.FpsDen),
+                    "UVC start");
+                break;
+            case AddOutputCommand add:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.OutputAdd(
+                        add.Output.Id,
+                        (uint)add.Output.Transport,
+                        add.Output.Name,
+                        (uint)add.Output.SourceKind,
+                        add.Output.SourceId,
+                        add.Output.UnitId,
+                        add.Output.UseGpu ? 1u : 0u),
+                    "Add output");
+                break;
+            case RemoveOutputCommand remove:
+                MixerNative.OutputRemove(remove.OutputId);
+                break;
+            case DefineGeneratorCommand generator:
+                MixerNative.ThrowIfFailed(
+                    MixerNative.DefineGenerator(
+                        generator.SourceId,
+                        generator.Kind,
+                        generator.R,
+                        generator.G,
+                        generator.B,
+                        1,
+                        generator.Scroll ? 1u : 0u),
+                    "Define colour generator");
+                MixerNative.GeneratorSetTone(generator.SourceId, generator.ToneHz, generator.ToneLevelDbfs);
+                break;
+            case DropSourceCommand drop:
+                MixerNative.DestroySource(drop.SourceId);
+                break;
+            default:
+                throw new InvalidOperationException("Unknown command.");
         }
     }
 

--- a/host/Dialogs/SwitcherWindow.xaml.cs
+++ b/host/Dialogs/SwitcherWindow.xaml.cs
@@ -259,6 +259,8 @@ public partial class SwitcherWindow : Window
             Commands.TryEnqueue(new CutCommand(_unit.Id, preset.Swap));
         else
             Commands.TryEnqueue(preset.ToAuto(_unit.Id, _unit));
+        RefreshBusTitles();
+        RefreshSceneThumbs();
     }
 
     private TransitionPreset TbarPreset()

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -250,6 +250,7 @@ public partial class MainWindow : Window
             Commands.TryEnqueue(new CutCommand(unit.Id, preset.Swap));
         else
             Commands.TryEnqueue(preset.ToAuto(unit.Id, unit));
+        RefreshSceneTiles();
     }
 
     private TransitionPreset TbarPreset()
@@ -1598,6 +1599,10 @@ public partial class MainWindow : Window
         PreviewHost.ReleaseNative();
         ProgramHost.ReleaseNative();
         ScenePanel.Children.Clear();
+        _selectedScene = null;
+        _lastProgramId = 0;
+        _shownProgramId = 0;
+        _shownPreviewId = 0;
         ((App)Application.Current).ReplaceSession(session);
         InputList.ItemsSource = _session.Inputs;
         UnitBox.ItemsSource = _session.Units;
@@ -1612,6 +1617,11 @@ public partial class MainWindow : Window
             SelectScene(_session.Scenes[0]);
         PreviewHost.RetargetUnit(SelectedUnit.Id, MixerNative.OutputPreview);
         ProgramHost.RetargetUnit(SelectedUnit.Id, MixerNative.OutputProgram);
+        Dispatcher.BeginInvoke(() =>
+        {
+            PreviewHost.ForceReattach();
+            ProgramHost.ForceReattach();
+        }, DispatcherPriority.Loaded);
         ApplyBusColors();
         ApplyAspect();
     }

--- a/host/Preview/SwapchainHost.cs
+++ b/host/Preview/SwapchainHost.cs
@@ -78,6 +78,12 @@ internal sealed partial class SwapchainHost : HwndHost
         ApplySize();
     }
 
+    public void ForceReattach()
+    {
+        DetachNative();
+        ApplySize();
+    }
+
     public bool HasMonitor(ulong monitorId, ulong sourceId) =>
         _attached && IsMonitor && MonitorId == monitorId && SourceId == sourceId;
 

--- a/mac/Sources/EivizMac/EivizMacApp.swift
+++ b/mac/Sources/EivizMac/EivizMacApp.swift
@@ -12,6 +12,7 @@ struct EivizMacApp: App {
         WindowGroup("eiviz") {
             ContentView()
                 .environmentObject(mixer)
+                .environment(\.mixerSurfaceEpoch, mixer.surfaceEpoch)
                 .frame(minWidth: 1280, minHeight: 720)
                 .onAppear { mixer.boot() }
                 .onDisappear { mixer.shutdown() }

--- a/mac/Sources/EivizMac/MetalPreviewView.swift
+++ b/mac/Sources/EivizMac/MetalPreviewView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 final class MetalSurfaceView: NSView {
     var presentInterval: UInt32 = 1
+    var surfaceEpoch: UInt64 = 0
     var role: SurfaceRole = .unit(unitId: 1, kind: EIVIZ_OUTPUT_PROGRAM) {
         didSet {
             if role != oldValue {
@@ -81,7 +82,7 @@ final class MetalSurfaceView: NSView {
         let (width, height) = pixelSize()
         guard width >= 16, height >= 16 else { return }
         let handle = Int(bitPattern: Unmanaged.passUnretained(self).toOpaque())
-        let key = role.key
+        let key = "\(role.key)#\(surfaceEpoch)"
         if !attached || attachedKey != key {
             if attached {
                 if detachIsMonitor {
@@ -192,7 +193,19 @@ final class PreviewHostView: NSView {
     }
 }
 
+private struct MixerSurfaceEpochKey: EnvironmentKey {
+    static let defaultValue: UInt64 = 0
+}
+
+extension EnvironmentValues {
+    var mixerSurfaceEpoch: UInt64 {
+        get { self[MixerSurfaceEpochKey.self] }
+        set { self[MixerSurfaceEpochKey.self] = newValue }
+    }
+}
+
 struct MetalPreviewRepresentable: NSViewRepresentable {
+    @Environment(\.mixerSurfaceEpoch) private var surfaceEpoch
     let role: SurfaceRole
     var presentInterval: UInt32 = 1
     var onClick: (() -> Void)? = nil
@@ -232,6 +245,9 @@ struct MetalPreviewRepresentable: NSViewRepresentable {
         }
         if surface.presentInterval != presentInterval {
             surface.presentInterval = presentInterval
+        }
+        if surface.surfaceEpoch != surfaceEpoch {
+            surface.surfaceEpoch = surfaceEpoch
         }
         if surface.role != role {
             surface.role = role

--- a/mac/Sources/EivizMac/MixerController.swift
+++ b/mac/Sources/EivizMac/MixerController.swift
@@ -42,6 +42,7 @@ final class MixerController: ObservableObject {
     @Published var openMultiview: MultiviewLayout?
     @Published var expandedTransitions: Set<UUID> = []
     @Published var kindMenuGroup: [UUID: TransitionGroup] = [:]
+    @Published private(set) var surfaceEpoch: UInt64 = 0
 
     private var booted = false
     private var tbarLatching = false
@@ -78,6 +79,7 @@ final class MixerController: ObservableObject {
         fail(mixer_set_ndi_gpu_upload(session.settings.ndiGpuUploadEnabled ? 1 : 0), "Set NDI GPU upload")
         applyBusColors()
         applySession()
+        bumpSurfaceEpoch()
         meterTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
@@ -633,7 +635,7 @@ final class MixerController: ObservableObject {
             existing.level = layout.alwaysOnTop ? .floating : .normal
             return
         }
-        let host = NSHostingController(rootView: MultiviewView(layoutId: layout.id).environmentObject(self))
+        let host = NSHostingController(rootView: MultiviewView(layoutId: layout.id).environmentObject(self).environment(\.mixerSurfaceEpoch, surfaceEpoch))
         let window = SwitcherHostWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1280, height: 792),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -668,7 +670,7 @@ final class MixerController: ObservableObject {
             existing.level = unit.alwaysOnTop ? .floating : .normal
             return
         }
-        let host = NSHostingController(rootView: SwitcherView(unitId: unit.id).environmentObject(self))
+        let host = NSHostingController(rootView: SwitcherView(unitId: unit.id).environmentObject(self).environment(\.mixerSurfaceEpoch, surfaceEpoch))
         let window = SwitcherHostWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1280, height: 640),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -948,6 +950,11 @@ final class MixerController: ObservableObject {
         fail(mixer_set_ndi_gpu_upload(session.settings.ndiGpuUploadEnabled ? 1 : 0), "Set NDI GPU upload")
         applyBusColors()
         applySession()
+        bumpSurfaceEpoch()
+    }
+
+    private func bumpSurfaceEpoch() {
+        surfaceEpoch &+= 1
     }
 
     private func closeAllMultiviews() {
@@ -1025,7 +1032,10 @@ final class MixerController: ObservableObject {
     }
 
     private func attachInputs() {
-        for input in session.inputs {
+        for input in session.inputs where input.kind != .omt && input.kind != .ndi {
+            attach(input)
+        }
+        for input in session.inputs where input.kind == .omt || input.kind == .ndi {
             attach(input)
         }
     }

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -1156,6 +1156,7 @@ pub extern "C" fn mixer_unit_cut(unit_id: u64, swap: u32, incoming_source: u64) 
             )
         };
         take_cut_to(unit, swap != 0, incoming);
+        shared.compose_dirty = true;
         OK
     })
     .unwrap_or_else(|code| code)
@@ -1221,6 +1222,7 @@ pub extern "C" fn mixer_unit_auto(
             frozen_preview: incoming,
             easing,
         });
+        shared.compose_dirty = true;
         OK
     })
     .unwrap_or_else(|code| code)

--- a/mixer/src/media.rs
+++ b/mixer/src/media.rs
@@ -58,6 +58,9 @@ impl VideoPump {
         uploads: Arc<Mutex<UploadStore>>,
         gpu: GpuVideoContext,
     ) -> Result<Self, String> {
+        if !capture && !std::path::Path::new(&path).is_file() {
+            return Err(format!("video file not found: {path}"));
+        }
         let stop = Arc::new(AtomicBool::new(false));
         let playing = Arc::new(AtomicBool::new(true));
         let looping = Arc::new(AtomicBool::new(true));
@@ -82,8 +85,8 @@ impl VideoPump {
                 }
             })
             .map_err(|error| error.to_string())?;
-        match ready_rx.recv_timeout(Duration::from_secs(30)) {
-            Ok(Ok(())) => Ok(Self {
+        match ready_rx.recv_timeout(Duration::from_millis(400)) {
+            Ok(Ok(())) | Err(mpsc::RecvTimeoutError::Timeout) => Ok(Self {
                 stop,
                 playing,
                 looping,
@@ -97,10 +100,6 @@ impl VideoPump {
                 stop.store(true, Ordering::Relaxed);
                 let _ = join.join();
                 Err(error)
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                stop.store(true, Ordering::Relaxed);
-                Err("timed out opening the video source".into())
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 stop.store(true, Ordering::Relaxed);

--- a/mixer/src/media_macos.rs
+++ b/mixer/src/media_macos.rs
@@ -189,6 +189,9 @@ impl VideoPump {
         fps_den: u32,
         uploads: Arc<Mutex<UploadStore>>,
     ) -> Result<Self, String> {
+        if !capture && !std::path::Path::new(&path).is_file() {
+            return Err(format!("video file not found: {path}"));
+        }
         let stop = Arc::new(AtomicBool::new(false));
         let playing = Arc::new(AtomicBool::new(true));
         let looping = Arc::new(AtomicBool::new(true));
@@ -213,8 +216,8 @@ impl VideoPump {
                 }
             })
             .map_err(|error| error.to_string())?;
-        match ready_rx.recv_timeout(Duration::from_secs(30)) {
-            Ok(Ok(())) => Ok(Self {
+        match ready_rx.recv_timeout(Duration::from_millis(400)) {
+            Ok(Ok(())) | Err(mpsc::RecvTimeoutError::Timeout) => Ok(Self {
                 stop,
                 playing,
                 looping,
@@ -228,10 +231,6 @@ impl VideoPump {
                 stop.store(true, Ordering::Relaxed);
                 let _ = join.join();
                 Err(error)
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                stop.store(true, Ordering::Relaxed);
-                Err("timed out opening the video source".into())
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 stop.store(true, Ordering::Relaxed);

--- a/mixer/src/omt.rs
+++ b/mixer/src/omt.rs
@@ -52,7 +52,6 @@ impl OmtReceiver {
             quality,
             ..ReceiverConfig::default()
         };
-        let session = connect_receiver(&address, config)?;
         let stop = Arc::new(AtomicBool::new(false));
         let want_full = Arc::new(AtomicBool::new(true));
         let on_program = Arc::new(AtomicBool::new(false));
@@ -66,6 +65,17 @@ impl OmtReceiver {
         let join = thread::Builder::new()
             .name(format!("eiviz-omt-{source_id}"))
             .spawn(move || {
+                let session = match connect_receiver(&address, config) {
+                    Ok(session) => session,
+                    Err(error) => {
+                        crate::diag::error(&format!("omt_connect id={source_id}: {error}"));
+                        return;
+                    }
+                };
+                if stop_thread.load(Ordering::Relaxed) {
+                    session.disconnect();
+                    return;
+                }
                 {
                     let mut store = uploads.lock().expect("uploads lock");
                     let format = if use_gpu {

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use eiviz_mixer::{
     ERR_INVALID_ARGUMENT, ERR_IO, ERR_NOT_CREATED, INCOMING_PROGRAM, MixerRebarInfo, OK, OUT_DECKLINK,
@@ -399,6 +399,71 @@ fn missing_video_file_returns_io_error() {
     let path = CString::new(r"C:\eiviz-missing-file-does-not-exist.mp4").unwrap();
     unsafe {
         assert_eq!(mixer_video_start(99, path.as_ptr(), 0, 0, 0, 0, 0, 0), ERR_IO);
+    }
+    mixer_destroy();
+}
+
+#[test]
+fn omt_connect_returns_before_unreachable_timeout() {
+    mixer_destroy();
+    assert_eq!(mixer_create(0, 60_000, 1_001), OK);
+    let address = CString::new("omt://127.0.0.1:1/missing").unwrap();
+    let started = Instant::now();
+    unsafe {
+        assert_eq!(mixer_omt_connect(20, address.as_ptr(), 0, 1, 0), OK);
+    }
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "omt connect blocked for {:?}",
+        started.elapsed()
+    );
+    mixer_destroy();
+}
+
+#[test]
+fn reload_mixer_then_preview_and_cut() {
+    mixer_destroy();
+    assert_eq!(mixer_create(0, 60_000, 1_001), OK);
+    assert_eq!(mixer_create_unit(1, 320, 180), OK);
+    let bars = full_layer(SRC_BARS);
+    let color = full_layer(SRC_COLOR);
+    unsafe {
+        assert_eq!(mixer_define_scene(scene_id(1), 320, 180, 1, &bars), OK);
+        assert_eq!(mixer_define_scene(scene_id(2), 320, 180, 1, &color), OK);
+        let state = UnitState {
+            program_source: scene_id(1),
+            preview_source: scene_id(2),
+            mix: 0.0,
+            ..UnitState::default()
+        };
+        assert_eq!(mixer_unit_set_state(1, &state), OK);
+    }
+    mixer_destroy();
+
+    assert_eq!(mixer_create(0, 60_000, 1_001), OK);
+    assert_eq!(mixer_create_unit(1, 320, 180), OK);
+    unsafe {
+        assert_eq!(mixer_define_scene(scene_id(1), 320, 180, 1, &bars), OK);
+        assert_eq!(mixer_define_scene(scene_id(2), 320, 180, 1, &color), OK);
+        let mut state = UnitState {
+            program_source: scene_id(1),
+            preview_source: scene_id(1),
+            mix: 0.0,
+            ..UnitState::default()
+        };
+        assert_eq!(mixer_unit_set_state(1, &state), OK);
+        state.preview_source = scene_id(2);
+        assert_eq!(mixer_unit_set_state(1, &state), OK);
+        let mut previewing = UnitState::default();
+        assert_eq!(mixer_unit_get_state(1, &mut previewing), OK);
+        assert_eq!(previewing.preview_source, scene_id(2));
+        assert_eq!(previewing.program_source, scene_id(1));
+        assert_eq!(mixer_unit_cut(1, 1, 0), OK);
+        let mut after = UnitState::default();
+        assert_eq!(mixer_unit_get_state(1, &mut after), OK);
+        assert_eq!(after.program_source, scene_id(2));
+        assert_eq!(after.preview_source, scene_id(1));
+        assert_eq!(after.mix, 0.0);
     }
     mixer_destroy();
 }


### PR DESCRIPTION
## Summary
- Apply Preview/Cut immediately instead of queuing them behind blocking OMT/video/UVC I/O, and rebind Preview/PGM after mixer recreate.
- Connect OMT in the background, return from video/UVC start without a 30s ready wait, and attach still/video/UVC before network sources.
- Run deferred input I/O in parallel so a dead OMT endpoint no longer delays video and UVC lock.

## Test plan
- Load a session with mixed OMT, NDI, video, and UVC (for example `all_input_types.eiviz.json`).
- Click a scene and TAKE immediately after load; Preview and PGM should switch without waiting for input connects.
- Confirm video and UVC show pictures without waiting for unreachable OMT/NDI timeouts.
- Reload the same session and confirm switching still works and local inputs come up promptly.