### PR TITLE
テキスチャ経路の文書化とGUI専用uploadの間隔化

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Latest release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=1" --jq '.[0].tag_name // empty')
+          echo "PUBLIC_EIVIZ_VERSION=$tag" >> "$GITHUB_ENV"
+
       - name: Install, build, and upload
         uses: withastro/action@v6
         with:
           path: docs
           node-version: 22
+        env:
+          PUBLIC_EIVIZ_VERSION: ${{ env.PUBLIC_EIVIZ_VERSION }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   deploy:
     name: Deploy to GitHub Pages

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,9 @@ Starlight starter (`npm create astro@latest -- --template starlight`).
 
 Public URL: [https://mikanseilaboratory.github.io/eiviz/](https://mikanseilaboratory.github.io/eiviz/)
 
-After each production deploy, `sitemap-index.xml` and `robots.txt` are published at the site root (`/eiviz/`). Submit this sitemap in [Google Search Console](https://search.google.com/search-console) for the `https://mikanseilaboratory.github.io/eiviz/` prefix:
+After each production deploy, `sitemap-index.xml` and `robots.txt` are at the site root (`/eiviz/`). An org owner submits this sitemap in [Google Search Console](https://search.google.com/search-console) for the prefix `https://mikanseilaboratory.github.io/eiviz/` (URL-prefix or HTML-file verification):
 
 - https://mikanseilaboratory.github.io/eiviz/sitemap-index.xml
-
-Search Console property verification has to be done by a GitHub org owner (URL-prefix or HTML-file). The build cannot register the property by itself.
 
 Japanese is the source of truth (`src/content/docs/ja/`). English lives in `src/content/docs/en/` with the same relative paths.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,12 @@ Starlight starter (`npm create astro@latest -- --template starlight`).
 
 Public URL: [https://mikanseilaboratory.github.io/eiviz/](https://mikanseilaboratory.github.io/eiviz/)
 
+After each production deploy, `sitemap-index.xml` and `robots.txt` are published at the site root (`/eiviz/`). Submit this sitemap in [Google Search Console](https://search.google.com/search-console) for the `https://mikanseilaboratory.github.io/eiviz/` prefix:
+
+- https://mikanseilaboratory.github.io/eiviz/sitemap-index.xml
+
+Search Console property verification has to be done by a GitHub org owner (URL-prefix or HTML-file). The build cannot register the property by itself.
+
 Japanese is the source of truth (`src/content/docs/ja/`). English lives in `src/content/docs/en/` with the same relative paths.
 
 Requires Node.js 22.12 or later.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,13 +1,48 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import starlight from '@astrojs/starlight';
 import mermaid from 'astro-mermaid';
+
+const SITE = 'https://mikanseilaboratory.github.io';
+const BASE = '/eiviz/';
+
+async function latestReleaseTag() {
+	if (process.env.PUBLIC_EIVIZ_VERSION) {
+		return process.env.PUBLIC_EIVIZ_VERSION;
+	}
+	try {
+		const headers = new Headers({
+			Accept: 'application/vnd.github+json',
+			'User-Agent': 'eiviz-docs',
+		});
+		if (process.env.GITHUB_TOKEN) {
+			headers.set('Authorization', `Bearer ${process.env.GITHUB_TOKEN}`);
+		}
+		const res = await fetch(
+			'https://api.github.com/repos/MikanseiLaboratory/eiviz/releases?per_page=1',
+			{ headers },
+		);
+		if (!res.ok) {
+			return '';
+		}
+		const releases = await res.json();
+		return typeof releases?.[0]?.tag_name === 'string' ? releases[0].tag_name : '';
+	} catch {
+		return '';
+	}
+}
+
+const version = await latestReleaseTag();
+if (version) {
+	process.env.PUBLIC_EIVIZ_VERSION = version;
+}
 
 // https://astro.build/config
 // GitHub Pages: https://mikanseilaboratory.github.io/eiviz/
 export default defineConfig({
-	site: 'https://mikanseilaboratory.github.io',
-	base: '/eiviz/',
+	site: SITE,
+	base: BASE,
 	integrations: [
 		mermaid({ autoTheme: true }),
 		starlight({
@@ -18,7 +53,17 @@ export default defineConfig({
 				alt: 'Mikansei Laboratory',
 			},
 			favicon: '/favicon.png',
+			components: {
+				Footer: './src/overrides/Footer.astro',
+			},
 			head: [
+				{
+					tag: 'link',
+					attrs: {
+						rel: 'sitemap',
+						href: `${BASE}sitemap-index.xml`,
+					},
+				},
 				{
 					tag: 'link',
 					attrs: {
@@ -117,6 +162,15 @@ export default defineConfig({
 					],
 				},
 			],
+		}),
+		sitemap({
+			i18n: {
+				defaultLocale: 'ja',
+				locales: {
+					ja: 'ja',
+					en: 'en',
+				},
+			},
 		}),
 	],
 });

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "docs",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.4",
         "@astrojs/starlight": "^0.41.11",
         "astro": "^7.1.6",
         "astro-mermaid": "^2.1.0",
@@ -212,56 +213,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
       "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.4",
-        "@types/mdast": "^4.0.4",
-        "js-yaml": "^4.3.0",
-        "picomatch": "^4.0.4",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.2",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5"
-      }
-    },
-    "node_modules/@astrojs/markdown-remark": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.3.0.tgz",
-      "integrity": "sha512-mRwn2W2PKkOj8XEAiD3b9RIF4qq6FKB6U4c98GxFLkEJH7uA6ZZv8TiqVjJSPMANLb1NtwBTgkY+KO4mTXnT/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.11.0",
-        "@astrojs/prism": "4.0.2",
-        "@mdx-js/mdx": "^3.1.1",
-        "acorn": "^8.16.0",
-        "estree-util-visit": "^2.0.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-html": "^9.0.5",
-        "hast-util-to-text": "^4.0.2",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "source-map": "^0.7.6",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.1.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
-      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
@@ -863,35 +814,12 @@
         "node": ">=14"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.4",
     "@astrojs/starlight": "^0.41.11",
     "astro": "^7.1.6",
     "astro-mermaid": "^2.1.0",

--- a/docs/src/content/docs/en/introduction/architecture.md
+++ b/docs/src/content/docs/en/introduction/architecture.md
@@ -81,7 +81,7 @@ flowchart LR
 
 ## Textures
 
-Inputs, scenes, a Mixing Unit’s Preview/Program, and Multiview all live in one source-id space as **GPU textures**. Compose and the GUI sample the `TextureView`; they do not clone the pixels.
+Inputs, scenes, a Mixing Unit’s Preview/Program, and Multiview all live in one source-id space as **GPU textures**. Compose and the GUI sample those `TextureView`s.
 
 | Kind | What it is |
 | --- | --- |
@@ -91,11 +91,11 @@ Inputs, scenes, a Mixing Unit’s Preview/Program, and Multiview all live in one
 | Preview | The Mixing Unit `preview` bus |
 | Program | `mixed` after mix and overlays. GUI and send point here |
 
-Program keeps a pre-mix `program` target and the on-air `mixed` target. Unused scenes stay in VRAM but are not redrawn.
+Program keeps a pre-mix `program` target and the on-air `mixed` target. Compose draws live scenes. Session scene textures stay allocated.
 
 ### Path to the GUI
 
-The host never receives GPU pointers except live preview surfaces. There are two paths.
+The host supplies the window surface; the mixer draws into it. There are two paths.
 
 ```mermaid
 flowchart TB
@@ -120,19 +120,19 @@ flowchart TB
   thumb --> tiles["List thumbnails"]
 ```
 
-Live Preview/Program, an open Multiview, Scene Editor, and the Overlay window blit an existing view into an HWND / NSView swapchain. That does not create a full-resolution copy of the source. Showing the same source on several surfaces adds blits, not extra source textures.
+Live Preview/Program, an open Multiview, Scene Editor, and the Overlay window blit an existing view into an HWND / NSView swapchain. Several live surfaces of the same source each blit that view.
 
-Input lists, scene lists, and switcher source buttons read back a downscale (up to 960×540). They do not use a swapchain slot.
+Input lists, scene lists, and switcher source buttons read back a downscale (up to 960×540).
 
-### Copies that cost bandwidth
+### GPU copies
 
-There is no full-resolution GUI duplicate. Bandwidth copies are:
+These copies run in the frame:
 
 - Frame Delay. Copies `mixed` and `preview` into a ring so picture lines up with audio. GUI Preview/Program sample that delayed surface
 - Transition history. Copies `mixed` into `prev`
 - Send. The CPU path packs UYVY; GPU OMT copies into an async send slot
 
-Intermediate buffers such as sort / flow / bloom stay in VRAM, but the compute runs only for those transitions.
+Intermediate buffers such as sort / flow / bloom stay in VRAM. Their compute runs during those transitions.
 
 ## One frame
 
@@ -140,9 +140,9 @@ A frame has three lanes:
 
 1. On-air ingest — every master frame
 2. On-air compose (Preview/Program/outputs) — every master frame
-3. Monitor compose (scene tiles, input preview) and GUI-only ingest — present interval only
+3. Monitor compose (scene tiles, input preview) and ingest for those sources — present interval
 
-Sources on-air upload every frame. An Input that lives only on a monitor or thumbnail waits for its interval before the GPU write. OMT receive quality still sees every attached monitor and thumb each tick, so TAKE and the T-bar do not flap quality.
+On-air sources upload every master frame. Monitor and thumbnail Inputs upload on their present interval. OMT receive quality reads every attached monitor and thumb each tick.
 
 Then the picture moves like this:
 

--- a/docs/src/content/docs/en/introduction/architecture.md
+++ b/docs/src/content/docs/en/introduction/architecture.md
@@ -79,9 +79,72 @@ flowchart LR
   compose --> mu
 ```
 
+## Textures
+
+Inputs, scenes, a Mixing Unit’s Preview/Program, and Multiview all live in one source-id space as **GPU textures**. Compose and the GUI sample the `TextureView`; they do not clone the pixels.
+
+| Kind | What it is |
+| --- | --- |
+| Input | Ingest result. GPU ingest shares the handle; CPU ingest overwrites one texture |
+| Scene | Composited layers |
+| Multiview | The same scene object, plus labels and tallies |
+| Preview | The Mixing Unit `preview` bus |
+| Program | `mixed` after mix and overlays. GUI and send point here |
+
+Program keeps a pre-mix `program` target and the on-air `mixed` target. Unused scenes stay in VRAM but are not redrawn.
+
+### Path to the GUI
+
+The host never receives GPU pointers except live preview surfaces. There are two paths.
+
+```mermaid
+flowchart TB
+  inp["Input"]
+  sc["Scene / MV"]
+  prv["MU preview"]
+  pgm["MU mixed"]
+  delay["Frame Delay"]
+  inp --> sc
+  inp --> prv
+  sc --> prv
+  prv --> pgm
+  pgm --> delay
+  prv --> delay
+  delay --> swap["swapchain blit"]
+  pgm --> swap
+  sc --> swap
+  inp --> swap
+  sc --> thumb["downscale blit + readback"]
+  inp --> thumb
+  swap --> live["Live surfaces"]
+  thumb --> tiles["List thumbnails"]
+```
+
+Live Preview/Program, an open Multiview, Scene Editor, and the Overlay window blit an existing view into an HWND / NSView swapchain. That does not create a full-resolution copy of the source. Showing the same source on several surfaces adds blits, not extra source textures.
+
+Input lists, scene lists, and switcher source buttons read back a downscale (up to 960×540). They do not use a swapchain slot.
+
+### Copies that cost bandwidth
+
+There is no full-resolution GUI duplicate. Bandwidth copies are:
+
+- Frame Delay. Copies `mixed` and `preview` into a ring so picture lines up with audio. GUI Preview/Program sample that delayed surface
+- Transition history. Copies `mixed` into `prev`
+- Send. The CPU path packs UYVY; GPU OMT copies into an async send slot
+
+Intermediate buffers such as sort / flow / bloom stay in VRAM, but the compute runs only for those transitions.
+
 ## One frame
 
-A frame goes like this:
+A frame has three lanes:
+
+1. On-air ingest — every master frame
+2. On-air compose (Preview/Program/outputs) — every master frame
+3. Monitor compose (scene tiles, input preview) and GUI-only ingest — present interval only
+
+Sources on-air upload every frame. An Input that lives only on a monitor or thumbnail waits for its interval before the GPU write. OMT receive quality still sees every attached monitor and thumb each tick, so TAKE and the T-bar do not flap quality.
+
+Then the picture moves like this:
 
 1. An ingest thread deposits the latest frame
 2. Each Mixing Unit draws Preview and Program, mixes with the T-bar or AUTO, then overlays and multiview

--- a/docs/src/content/docs/ja/introduction/architecture.md
+++ b/docs/src/content/docs/ja/introduction/architecture.md
@@ -80,9 +80,72 @@ flowchart LR
   compose --> mu
 ```
 
+## テキスチャ
+
+Input、Scene、Mixing UnitのPreview/Program、Multiviewは、同じソースID空間の**GPUテキスチャ**として持ちます。合成とGUIは画素を複製せず、その`TextureView`をサンプリングします。
+
+| 種別 | 実体 |
+| --- | --- |
+| Input | 取り込み結果。GPU経路はハンドル共有、CPU経路は1枚へ上書き |
+| Scene | レイヤーを描いた合成結果 |
+| Multiview | Sceneと同じ実体。ラベルとタリーを足す |
+| Preview | Mixing Unitのpreview |
+| Program | mixとオーバーレイ後のmixed。GUIと送出が指す |
+
+Program用に切替前の`program`と、本線の`mixed`を分けます。未使用のSceneはVRAMに残しますが、描き直しません。
+
+### GUIへの経路
+
+ホストはライブ面以外にGPUポインタを渡しません。経路は2本です。
+
+```mermaid
+flowchart TB
+  inp["Input"]
+  sc["Scene / MV"]
+  prv["MU preview"]
+  pgm["MU mixed"]
+  delay["Frame Delay"]
+  inp --> sc
+  inp --> prv
+  sc --> prv
+  prv --> pgm
+  pgm --> delay
+  prv --> delay
+  delay --> swap["swapchain blit"]
+  pgm --> swap
+  sc --> swap
+  inp --> swap
+  sc --> thumb["縮小blit + 読み戻し"]
+  inp --> thumb
+  swap --> live["ライブ面"]
+  thumb --> tiles["一覧サムネ"]
+```
+
+ライブのPreview/Program、開いているMultiview、Scene Editor、Overlay窓は、既存のViewをHWND/NSViewのswapchainへblitします。ソースのフル解像度コピーは作りません。同じソースを複数面に出しても、増えるのはblit回数です。
+
+Input一覧、Scene一覧、スイッチャーのソースボタンは、最大960×540へ縮小してGPUから読み戻します。swapchain枠は使いません。
+
+### 帯域を使うコピー
+
+GUI用のフル解像度複製はありません。帯域を使うコピーは次です。
+
+- Frame Delay。`mixed`と`preview`をリングへコピーし、音声と揃えます。GUIのPreview/Programもこの遅延面を見ます
+- トランジション履歴。`mixed`を`prev`へコピーします
+- 送出。CPU経路はUYVYへパックし、GPU経路のOMTは非同期送出用にコピーします
+
+sort/flow/bloomなどの中間バッファはVRAMに確保しますが、該当トランジションのときだけ計算します。
+
 ## 1フレーム
 
-1フレームの流れは次のとおりです。
+1フレームは次の3レーンです。
+
+1. 本線の取り込み。毎マスターフレーム
+2. 本線の合成（Preview/Program/出力）。毎マスターフレーム
+3. 監視用の合成（Sceneタイル、入力プレビュー）と、GUI専用ソースの取り込み。更新間隔のときだけ
+
+本線に乗っているソースは毎フレームGPUへ載せます。Monitorやサムネにだけ載っているInputは、更新間隔が来るまで書きません。OMT受信の品質判定は、開いている監視面を毎フレーム見ます。TAKEやTバーで品質がちらつかないようにするためです。
+
+そのうえで流れは次のとおりです。
 
 1. 入力スレッドが最新フレームを置く
 2. Mixing UnitごとにPreviewとProgramを描き、TバーやAUTOのmixで混ぜ、オーバーレイとマルチビューを載せる

--- a/docs/src/content/docs/ja/introduction/architecture.md
+++ b/docs/src/content/docs/ja/introduction/architecture.md
@@ -82,7 +82,7 @@ flowchart LR
 
 ## テキスチャ
 
-Input、Scene、Mixing UnitのPreview/Program、Multiviewは、同じソースID空間の**GPUテキスチャ**として持ちます。合成とGUIは画素を複製せず、その`TextureView`をサンプリングします。
+Input、Scene、Mixing UnitのPreview/Program、Multiviewは、同じソースID空間の**GPUテキスチャ**です。合成とGUIは、その`TextureView`をサンプリングします。
 
 | 種別 | 実体 |
 | --- | --- |
@@ -92,11 +92,11 @@ Input、Scene、Mixing UnitのPreview/Program、Multiviewは、同じソースID
 | Preview | Mixing Unitのpreview |
 | Program | mixとオーバーレイ後のmixed。GUIと送出が指す |
 
-Program用に切替前の`program`と、本線の`mixed`を分けます。未使用のSceneはVRAMに残しますが、描き直しません。
+Programは切替前の`program`と、本線の`mixed`を持ちます。合成は使用中のSceneを描き、セッション上のSceneテキスチャは保持します。
 
 ### GUIへの経路
 
-ホストはライブ面以外にGPUポインタを渡しません。経路は2本です。
+ホストはウィンドウ面を用意し、Mixerがそこに描きます。経路は2本です。
 
 ```mermaid
 flowchart TB
@@ -121,19 +121,19 @@ flowchart TB
   thumb --> tiles["一覧サムネ"]
 ```
 
-ライブのPreview/Program、開いているMultiview、Scene Editor、Overlay窓は、既存のViewをHWND/NSViewのswapchainへblitします。ソースのフル解像度コピーは作りません。同じソースを複数面に出しても、増えるのはblit回数です。
+ライブのPreview/Program、開いているMultiview、Scene Editor、Overlay窓は、既存のViewをHWND/NSViewのswapchainへblitします。同じソースを複数のライブ面に出すと、面の数だけblitします。
 
-Input一覧、Scene一覧、スイッチャーのソースボタンは、最大960×540へ縮小してGPUから読み戻します。swapchain枠は使いません。
+Input一覧、Scene一覧、スイッチャーのソースボタンは、最大960×540へ縮小してGPUから読み戻します。
 
-### 帯域を使うコピー
+### GPU上のコピー
 
-GUI用のフル解像度複製はありません。帯域を使うコピーは次です。
+次のコピーがフレーム処理に入ります。
 
 - Frame Delay。`mixed`と`preview`をリングへコピーし、音声と揃えます。GUIのPreview/Programもこの遅延面を見ます
 - トランジション履歴。`mixed`を`prev`へコピーします
-- 送出。CPU経路はUYVYへパックし、GPU経路のOMTは非同期送出用にコピーします
+- 送出。CPU経路はUYVYへパックし、GPU経路のOMTは非同期送出用スロットへコピーします
 
-sort/flow/bloomなどの中間バッファはVRAMに確保しますが、該当トランジションのときだけ計算します。
+sort/flow/bloomなどの中間バッファはVRAMにあり、該当トランジションのときに計算します。
 
 ## 1フレーム
 
@@ -141,9 +141,9 @@ sort/flow/bloomなどの中間バッファはVRAMに確保しますが、該当�
 
 1. 本線の取り込み。毎マスターフレーム
 2. 本線の合成（Preview/Program/出力）。毎マスターフレーム
-3. 監視用の合成（Sceneタイル、入力プレビュー）と、GUI専用ソースの取り込み。更新間隔のときだけ
+3. 監視用の合成（Sceneタイル、入力プレビュー）と、そのソースの取り込み。更新間隔のとき
 
-本線に乗っているソースは毎フレームGPUへ載せます。Monitorやサムネにだけ載っているInputは、更新間隔が来るまで書きません。OMT受信の品質判定は、開いている監視面を毎フレーム見ます。TAKEやTバーで品質がちらつかないようにするためです。
+本線のソースは毎フレームGPUへ載せます。MonitorとサムネのInputは、それぞれの更新間隔でGPUへ載せます。OMT受信の品質判定は、開いている監視面を毎フレーム見ます。
 
 そのうえで流れは次のとおりです。
 

--- a/docs/src/overrides/Footer.astro
+++ b/docs/src/overrides/Footer.astro
@@ -1,0 +1,42 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro';
+
+const version = import.meta.env.PUBLIC_EIVIZ_VERSION as string;
+const locale = Astro.locals.starlightRoute.lang ?? 'ja';
+const english = locale.startsWith('en');
+---
+
+<Default>
+	<slot />
+</Default>
+{
+	version && (
+		<p class="eiviz-version">
+			{
+				english ? (
+					<>
+						Latest:{' '}
+						<a href="https://github.com/MikanseiLaboratory/eiviz/releases/latest">
+							{version}
+						</a>
+					</>
+				) : (
+					<a href="https://github.com/MikanseiLaboratory/eiviz/releases/latest">
+						最新リリース（{version}）
+					</a>
+				)
+			}
+		</p>
+	)
+}
+
+<style>
+	.eiviz-version {
+		margin-block-start: 1rem;
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-3);
+	}
+	.eiviz-version a {
+		color: inherit;
+	}
+</style>

--- a/docs/src/pages/robots.txt.ts
+++ b/docs/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = ({ site }) => {
+	const origin = site ?? new URL('https://mikanseilaboratory.github.io');
+	const sitemapURL = new URL(`${import.meta.env.BASE_URL}sitemap-index.xml`, origin);
+	const body = `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
+	});
+};

--- a/mixer/src/audio/graph.rs
+++ b/mixer/src/audio/graph.rs
@@ -2,9 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::abi::{
-    MixInputSpec, OverlayDesc, UnitState, is_scene, mixing_unit_from_source,
-};
+use crate::abi::{MixInputSpec, OverlayDesc, UnitState, is_scene, mixing_unit_from_source};
 use crate::upload::{AUDIO_FIFO_FRAMES, AUDIO_RATE, SampleRing, UploadStore};
 
 use super::AUDIO_PRIME_FRAMES;
@@ -323,7 +321,8 @@ impl AudioGraph {
                     ids.push(*id);
                 }
             }
-            self.popped.retain(|id, _| ids.contains(id) || mix_inputs.contains_key(id));
+            self.popped
+                .retain(|id, _| ids.contains(id) || mix_inputs.contains_key(id));
             for id in ids {
                 if mix_inputs.contains_key(&id) {
                     continue;
@@ -355,13 +354,7 @@ impl AudioGraph {
                     self.scratch_mixed.extend_from_slice(&self.scratch_master);
                     crate::simd::scale_f32(&mut self.scratch_mixed, fader);
                     self.push_mix_from_bus(bus_id, mix_inputs);
-                    self.mix_self_copies(
-                        bus_id,
-                        role,
-                        snapshot,
-                        &spec_map,
-                        mix_inputs,
-                    );
+                    self.mix_self_copies(bus_id, role, snapshot, &spec_map, mix_inputs);
                     if let Some(bus) = self.buses.iter_mut().find(|bus| bus.id == bus_id) {
                         bus.peak = crate::simd::peak_interleaved(&self.scratch_mixed);
                     }
@@ -382,13 +375,7 @@ impl AudioGraph {
                 }
                 crate::simd::scale_f32(&mut self.scratch_mixed, fader);
                 self.push_mix_from_bus(bus_id, mix_inputs);
-                self.mix_self_copies(
-                    bus_id,
-                    role,
-                    snapshot,
-                    &spec_map,
-                    mix_inputs,
-                );
+                self.mix_self_copies(bus_id, role, snapshot, &spec_map, mix_inputs);
                 if role == ROLE_MASTER {
                     self.scratch_master.copy_from_slice(&self.scratch_mixed);
                     self.master_peak = crate::simd::peak_interleaved(&self.scratch_mixed);
@@ -738,7 +725,11 @@ fn add_source(
         if spec.audio_bus_id == 0 || spec.audio_bus_id == bus_id {
             return;
         }
-        let level = gain * inputs.get(&id).map(|input| input.gain.max(0.0)).unwrap_or(1.0);
+        let level = gain
+            * inputs
+                .get(&id)
+                .map(|input| input.gain.max(0.0))
+                .unwrap_or(1.0);
         gains
             .entry(id)
             .and_modify(|current| *current = (*current).max(level))
@@ -797,7 +788,11 @@ fn add_self_mix(
     if spec.audio_bus_id == 0 || spec.audio_bus_id != bus_id {
         return;
     }
-    let level = gain * inputs.get(&id).map(|input| input.gain.max(0.0)).unwrap_or(1.0);
+    let level = gain
+        * inputs
+            .get(&id)
+            .map(|input| input.gain.max(0.0))
+            .unwrap_or(1.0);
     gains
         .entry(id)
         .and_modify(|current| *current = (*current).max(level))

--- a/mixer/src/audio/mod.rs
+++ b/mixer/src/audio/mod.rs
@@ -239,15 +239,7 @@ impl AudioEngine {
         let mut graph = self.graph.lock().expect("audio");
         let mut delay = self.delay.lock().expect("audio delay");
         graph.mix(
-            uploads,
-            snapshot,
-            scenes,
-            frames,
-            &mut delay,
-            produce,
-            mix_inputs,
-            fps_num,
-            fps_den,
+            uploads, snapshot, scenes, frames, &mut delay, produce, mix_inputs, fps_num, fps_den,
         )
     }
 

--- a/mixer/src/compose.rs
+++ b/mixer/src/compose.rs
@@ -214,6 +214,7 @@ pub struct Composer {
     fx2_layout: wgpu::BindGroupLayout,
     user_cs_layout: wgpu::BindGroupLayout,
     pack_groups: HashMap<u64, wgpu::BindGroup>,
+    mix_textures: HashMap<u64, wgpu::Texture>,
     mix_aliases: HashMap<u64, wgpu::TextureView>,
     color_group: wgpu::BindGroup,
     gpu_epoch: u64,
@@ -442,6 +443,7 @@ impl Composer {
             fx2_layout,
             user_cs_layout,
             pack_groups: HashMap::new(),
+            mix_textures: HashMap::new(),
             mix_aliases: HashMap::new(),
             color_group,
             gpu_epoch: 1,
@@ -514,8 +516,44 @@ impl Composer {
         }
     }
 
-    pub fn set_mix_aliases(&mut self, aliases: HashMap<u64, wgpu::TextureView>) {
-        self.mix_aliases = aliases;
+    /// Copy each Mix Input's delay-ring slot into a stable texture so blit /
+    /// pack bind groups stay valid. Ring wrap must not drop the update rate.
+    pub fn stage_mix_inputs(
+        &mut self,
+        device: &GpuDevice,
+        encoder: &mut wgpu::CommandEncoder,
+        live: impl IntoIterator<Item = u64>,
+        sources: &HashMap<u64, &wgpu::Texture>,
+    ) {
+        let live: HashSet<u64> = live.into_iter().collect();
+        self.mix_textures.retain(|id, _| live.contains(id));
+        self.mix_aliases.retain(|id, _| live.contains(id));
+        for (id, src) in sources {
+            let size = src.size();
+            let recreate = self.mix_textures.get(id).is_none_or(|tex| {
+                tex.size().width != size.width || tex.size().height != size.height
+            });
+            if recreate {
+                let usage = wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::COPY_SRC;
+                let texture = make_texture(device, size.width, size.height, usage);
+                let view = texture.create_view(&Default::default());
+                self.mix_textures.insert(*id, texture);
+                self.mix_aliases.insert(*id, view);
+                self.blit_groups.remove(id);
+                self.uyvy_groups.remove(id);
+                self.pack_groups.remove(&(0x4000_0000_0000_0000 | *id));
+                self.gpu_epoch = self.gpu_epoch.wrapping_add(1);
+            }
+            if let Some(dst) = self.mix_textures.get(id) {
+                copy_texture(encoder, src, dst);
+            }
+        }
+    }
+
+    pub fn mix_texture(&self, source_id: u64) -> Option<&wgpu::Texture> {
+        self.mix_textures.get(&source_id)
     }
 
     pub fn upload_sources(
@@ -2298,6 +2336,9 @@ impl Composer {
                 total += texture_bytes(packed);
             }
         }
+        for texture in self.mix_textures.values() {
+            total += texture_bytes(texture);
+        }
         for texture in self.input_packed.values() {
             total += texture_bytes(texture);
         }
@@ -2662,6 +2703,22 @@ fn color_for(id: u64) -> [f32; 4] {
         SRC_BLACK => [0.0, 0.0, 0.0, 1.0],
         _ => [1.0, 0.0, 0.0, 1.0],
     }
+}
+
+fn copy_texture(encoder: &mut wgpu::CommandEncoder, src: &wgpu::Texture, dst: &wgpu::Texture) {
+    let size = src.size();
+    if size != dst.size() {
+        return;
+    }
+    encoder.copy_texture_to_texture(
+        src.as_image_copy(),
+        dst.as_image_copy(),
+        wgpu::Extent3d {
+            width: size.width,
+            height: size.height,
+            depth_or_array_layers: 1,
+        },
+    );
 }
 
 fn make_texture(

--- a/mixer/src/delay.rs
+++ b/mixer/src/delay.rs
@@ -293,7 +293,10 @@ impl FrameDelay {
         let depth = self.depth;
         let cap = depth + 1;
         let recreate = self.scenes.get(&scene_id).is_none_or(|ring| {
-            ring.width != width || ring.height != height || ring.depth != depth || ring.slots.len() != cap
+            ring.width != width
+                || ring.height != height
+                || ring.depth != depth
+                || ring.slots.len() != cap
         });
         if !recreate {
             return;

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -40,9 +40,9 @@ pub use abi::{
     EASING_SMOOTHSTEP, ERR_ALREADY_CREATED, ERR_DEVICE, ERR_INVALID_ARGUMENT, ERR_IO,
     ERR_NOT_CREATED, GEN_BARS, GEN_SOLID, INCOMING_PREVIEW, INCOMING_PROGRAM, MixerRebarInfo,
     MixerStats, MixerVideoInfo, NATIVE_APPKIT_NSVIEW, NATIVE_WIN32_HWND, OK, OUT_DECKLINK, OUT_NDI,
-    OUT_OMT, OUTPUT_PREVIEW, OUTPUT_PROGRAM, OverlayDesc, Rect,
-    SAVE_FLAG_MULTIVIEW, SAVE_NOT_ON_PREVIEW_OR_PROGRAM, SCENE_BASE, SRC_BARS, SRC_BLACK, SRC_BLUE,
-    SRC_COLOR, SRC_KIND_INPUT, SRC_KIND_MU_MULTIVIEW, SRC_KIND_MU_PREVIEW, SRC_KIND_MU_PROGRAM,
+    OUT_OMT, OUTPUT_PREVIEW, OUTPUT_PROGRAM, OverlayDesc, Rect, SAVE_FLAG_MULTIVIEW,
+    SAVE_NOT_ON_PREVIEW_OR_PROGRAM, SCENE_BASE, SRC_BARS, SRC_BLACK, SRC_BLUE, SRC_COLOR,
+    SRC_KIND_INPUT, SRC_KIND_MU_MULTIVIEW, SRC_KIND_MU_PREVIEW, SRC_KIND_MU_PROGRAM,
     SRC_KIND_SCENE, SourceUsage, TRANSITION_ADDITIVE, TRANSITION_BARN_DOOR, TRANSITION_BLINDS,
     TRANSITION_BLOOM, TRANSITION_CLOCK, TRANSITION_CROSS_ZOOM, TRANSITION_CUBE,
     TRANSITION_CUBE_ZOOM, TRANSITION_CUSTOM, TRANSITION_CUT, TRANSITION_DATAMOSH,
@@ -3328,13 +3328,12 @@ fn render_loop(
                 .collect();
             frame_i = frame_i.wrapping_add(1);
             // Three lanes:
-            // 1. Playout/upload — every master frame (FIFOs and live pixels).
+            // 1. On-air playout/upload — every master frame (FIFOs and live pixels).
             // 2. On-air compose (Preview/Program/outputs) — every master frame.
-            // 3. Monitor compose (scene tiles, input preview) — present_interval only.
-            // Lane 3 uses due monitors only; every attached monitor still uploads.
-            let monitor_sources = presenters.attached_monitor_sources();
+            // 3. Monitor compose and GUI-only upload — present_interval only.
+            // Save roles still see every attached monitor/thumb so OMT quality
+            // does not flap on skipped present ticks.
             let due_monitors = presenters.attached_monitor_sources_due(frame_i);
-            let thumb_ids: Vec<u64> = thumbs_snap.keys().copied().collect();
             let due_thumbs: Vec<u64> = thumbs_snap
                 .iter()
                 .filter(|(_, sub)| frame_i % u64::from(sub.interval) == 0)
@@ -3342,29 +3341,21 @@ fn render_loop(
                 .collect();
             let mut compose_sources = due_monitors;
             compose_sources.extend_from_slice(&due_thumbs);
-            let mut upload_sources = monitor_sources.clone();
-            upload_sources.extend_from_slice(&thumb_ids);
-            let (mut used_scenes, mut used_uploads) = collect_live_ids(
+            let (mut used_scenes, used_uploads) = collect_frame_live_ids(
                 &scene_specs,
                 &snapshot,
                 &compose_sources,
                 &outputs_snap,
                 &mix_inputs,
+                compose_dirty,
             );
-            let (_, monitor_uploads) =
-                collect_live_ids(&scene_specs, &[], &upload_sources, &[], &mix_inputs);
-            used_uploads.extend(monitor_uploads);
-            if compose_dirty {
-                for (id, ..) in &scene_specs {
-                    used_scenes.insert(*id);
-                }
-            }
+            let mut role_sources = presenters.attached_monitor_sources();
+            role_sources.extend(thumbs_snap.keys().copied());
             let output_refs: Vec<(u32, u64)> = outputs_snap
                 .iter()
                 .map(|item| (item.source_kind, item.source_id))
                 .collect();
-            let roles =
-                collect_source_roles(&scene_specs, &snapshot, &upload_sources, &output_refs);
+            let roles = collect_source_roles(&scene_specs, &snapshot, &role_sources, &output_refs);
             {
                 let guard = shared.lock().expect("shared");
                 for (id, receiver) in &guard.receivers {
@@ -3980,9 +3971,10 @@ fn mix_source_cycles(
         return true;
     }
     if let Some(scene) = scenes.get(&source_id) {
-        return scene.layers.iter().any(|layer| {
-            mix_source_cycles(layer.source_id, unit_id, mix_inputs, scenes, seen)
-        });
+        return scene
+            .layers
+            .iter()
+            .any(|layer| mix_source_cycles(layer.source_id, unit_id, mix_inputs, scenes, seen));
     }
     false
 }
@@ -4020,6 +4012,25 @@ fn mix_rgba_at<'a>(
     } else {
         None
     }
+}
+
+fn collect_frame_live_ids(
+    scene_specs: &[(u64, u32, u32, Arc<[OverlayDesc]>, MvLabelStyle)],
+    snapshot: &[UnitSnap],
+    due_gui: &[u64],
+    outputs: &[OutputSnap],
+    mix_inputs: &HashMap<u64, MixInputSpec>,
+    compose_dirty: bool,
+) -> (HashSet<u64>, HashSet<u64>) {
+    let (mut scenes, mut uploads) =
+        collect_live_ids(scene_specs, snapshot, due_gui, outputs, mix_inputs);
+    if compose_dirty {
+        let dirty: Vec<u64> = scene_specs.iter().map(|spec| spec.0).collect();
+        scenes.extend(dirty.iter().copied());
+        let (_, dirty_uploads) = collect_live_ids(scene_specs, &[], &dirty, &[], mix_inputs);
+        uploads.extend(dirty_uploads);
+    }
+    (scenes, uploads)
 }
 
 fn collect_live_ids(
@@ -4295,6 +4306,53 @@ mod tests {
         let specs = [(idle, 1920, 1080, empty, MvLabelStyle::default())];
         let (scenes, _) = collect_live_ids(&specs, &[], &[idle], &[], &HashMap::new());
         assert!(scenes.contains(&idle));
+    }
+
+    #[test]
+    fn collect_frame_live_ids_uploads_on_air_not_idle_gui() {
+        let on_air = 20;
+        let idle = 21;
+        let snapshot = [(
+            1,
+            1920,
+            1080,
+            60_000,
+            1_001,
+            crate::abi::UnitState {
+                program_source: on_air,
+                preview_source: on_air,
+                ..crate::abi::UnitState::default()
+            },
+            0,
+            None,
+        )];
+        let (_, uploads) = collect_frame_live_ids(&[], &snapshot, &[], &[], &HashMap::new(), false);
+        assert!(uploads.contains(&on_air));
+        assert!(!uploads.contains(&idle));
+        let (_, uploads) =
+            collect_frame_live_ids(&[], &snapshot, &[idle], &[], &HashMap::new(), false);
+        assert!(uploads.contains(&on_air));
+        assert!(uploads.contains(&idle));
+    }
+
+    #[test]
+    fn collect_frame_live_ids_dirty_uploads_idle_scene_layers() {
+        let layer = 22;
+        let idle = SCENE_BASE | 4;
+        let layers: std::sync::Arc<[crate::abi::OverlayDesc]> =
+            std::sync::Arc::from([crate::abi::OverlayDesc {
+                source_id: layer,
+                ..crate::abi::OverlayDesc::default()
+            }]);
+        let specs = [(idle, 1920, 1080, layers, MvLabelStyle::default())];
+        let (scenes, uploads) =
+            collect_frame_live_ids(&specs, &[], &[], &[], &HashMap::new(), false);
+        assert!(!scenes.contains(&idle));
+        assert!(!uploads.contains(&layer));
+        let (scenes, uploads) =
+            collect_frame_live_ids(&specs, &[], &[], &[], &HashMap::new(), true);
+        assert!(scenes.contains(&idle));
+        assert!(uploads.contains(&layer));
     }
 
     #[test]

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -3402,7 +3402,6 @@ fn render_loop(
             let need_prv = outputs_snap
                 .iter()
                 .any(|item| item.source_kind == SRC_KIND_MU_PREVIEW && item.cpu_video());
-            composer.set_mix_aliases(resolve_mix_aliases(&mix_inputs, &frame_delay));
             let present_epoch = composer.gpu_epoch() ^ frame_delay.epoch().rotate_left(8);
             match panic::catch_unwind(AssertUnwindSafe(|| {
                 presenters.present_unit_buses(&device, present_epoch, |unit_id, kind| {
@@ -3514,6 +3513,15 @@ fn render_loop(
                     .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                         label: Some("eiviz compose"),
                     });
+            {
+                let mix_sources = resolve_mix_sources(&mix_inputs, &frame_delay);
+                composer.stage_mix_inputs(
+                    &device,
+                    &mut encoder,
+                    mix_inputs.keys().copied(),
+                    &mix_sources,
+                );
+            }
             if let Err(error) =
                 composer.render_scenes(&device, &used_scenes, &mut encoder, &tallies)
             {
@@ -3585,7 +3593,8 @@ fn render_loop(
                     continue;
                 }
                 let src = match output.source_kind {
-                    SRC_KIND_INPUT => mix_rgba_at(&mix_inputs, &frame_delay, output.source_id)
+                    SRC_KIND_INPUT => composer
+                        .mix_texture(output.source_id)
                         .or_else(|| composer.source_texture(output.source_id)),
                     SRC_KIND_SCENE | SRC_KIND_MU_MULTIVIEW => {
                         composer.scene_texture(output.source_id)
@@ -3979,24 +3988,17 @@ fn mix_source_cycles(
     false
 }
 
-fn resolve_mix_aliases(
+fn resolve_mix_sources<'a>(
     mix_inputs: &HashMap<u64, MixInputSpec>,
-    frame_delay: &FrameDelay,
-) -> HashMap<u64, wgpu::TextureView> {
-    let mut aliases = HashMap::new();
-    for (id, spec) in mix_inputs {
-        let view = if spec.is_session_multiview() {
-            frame_delay.scene_view_at(spec.target_id, spec.delay)
-        } else if let Some(bus) = spec.unit_bus() {
-            frame_delay.view_at(spec.target_id, bus, spec.delay)
-        } else {
-            None
-        };
-        if let Some(view) = view {
-            aliases.insert(*id, view);
+    frame_delay: &'a FrameDelay,
+) -> HashMap<u64, &'a wgpu::Texture> {
+    let mut sources = HashMap::new();
+    for id in mix_inputs.keys() {
+        if let Some(texture) = mix_rgba_at(mix_inputs, frame_delay, *id) {
+            sources.insert(*id, texture);
         }
     }
-    aliases
+    sources
 }
 
 fn mix_rgba_at<'a>(

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -6,19 +6,17 @@ use eiviz_mixer::{
     EASING_IN_OUT, ERR_INVALID_ARGUMENT, ERR_IO, ERR_NOT_CREATED, INCOMING_PROGRAM, MixerRebarInfo,
     OK, OUT_DECKLINK, OUT_OMT, OverlayDesc, Rect, SCENE_BASE, SRC_BARS, SRC_BLUE, SRC_COLOR,
     SRC_KIND_MU_PREVIEW, SRC_KIND_MU_PROGRAM, TRANSITION_BLOOM, TRANSITION_CUBE,
-    TRANSITION_CUBE_ZOOM,
-    TRANSITION_DATAMOSH, TRANSITION_DIP, TRANSITION_FADE, TRANSITION_FLY_ROTATE, TRANSITION_GLITCH,
-    TRANSITION_HEART, TRANSITION_LOREZ, TRANSITION_METAMIX, TRANSITION_MULTITASK,
-    TRANSITION_OPTICAL_FLOW, TRANSITION_PAGE_CURL, TRANSITION_PARTS, TRANSITION_PIXEL_SORT,
-    TRANSITION_SLIDE, TRANSITION_STAR, TRANSITION_SWIRL, TRANSITION_TILE,
-    TRANSITION_VISUAL_DISSOLVE, TRANSITION_WIPE, UnitState, VideoCaptureInfo,
+    TRANSITION_CUBE_ZOOM, TRANSITION_DATAMOSH, TRANSITION_DIP, TRANSITION_FADE,
+    TRANSITION_FLY_ROTATE, TRANSITION_GLITCH, TRANSITION_HEART, TRANSITION_LOREZ,
+    TRANSITION_METAMIX, TRANSITION_MULTITASK, TRANSITION_OPTICAL_FLOW, TRANSITION_PAGE_CURL,
+    TRANSITION_PARTS, TRANSITION_PIXEL_SORT, TRANSITION_SLIDE, TRANSITION_STAR, TRANSITION_SWIRL,
+    TRANSITION_TILE, TRANSITION_VISUAL_DISSOLVE, TRANSITION_WIPE, UnitState, VideoCaptureInfo,
     mixer_audio_bus_count, mixer_copy_rebar_info, mixer_create, mixer_create_unit,
     mixer_define_mix_input, mixer_define_scene, mixer_destroy, mixer_omt_connect,
-    mixer_omt_start_send, mixer_output_add,
-    mixer_ping, mixer_set_live_save, mixer_set_ndi_gpu_upload, mixer_set_rebar_optimization,
-    mixer_unit_acquire_frame, mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state,
-    mixer_unit_release_frame, mixer_unit_set_state, mixer_validate_custom_wgsl,
-    mixer_video_enum_captures, mixer_video_start,
+    mixer_omt_start_send, mixer_output_add, mixer_ping, mixer_set_live_save,
+    mixer_set_ndi_gpu_upload, mixer_set_rebar_optimization, mixer_unit_acquire_frame,
+    mixer_unit_auto, mixer_unit_cut, mixer_unit_get_state, mixer_unit_release_frame,
+    mixer_unit_set_state, mixer_validate_custom_wgsl, mixer_video_enum_captures, mixer_video_start,
 };
 #[cfg(windows)]
 use eiviz_mixer::{OUT_NDI, mixer_ndi_discover, mixer_output_remove};
@@ -417,7 +415,10 @@ fn mix_input_define_and_self_cycle_rejected() {
     assert_eq!(mixer_create_unit(2, 320, 180), OK);
     assert_eq!(mixer_define_mix_input(20, 1, SRC_KIND_MU_PROGRAM, 2, 0), OK);
     assert_eq!(mixer_define_mix_input(21, 2, SRC_KIND_MU_PREVIEW, 1, 1), OK);
-    assert_eq!(mixer_define_mix_input(0, 1, SRC_KIND_MU_PROGRAM, 1, 0), ERR_INVALID_ARGUMENT);
+    assert_eq!(
+        mixer_define_mix_input(0, 1, SRC_KIND_MU_PROGRAM, 1, 0),
+        ERR_INVALID_ARGUMENT
+    );
 
     let mut cycle = UnitState {
         program_source: 20,


### PR DESCRIPTION
## 概要
- 日英のシステムアーキテクチャに、Input / Scene / PRV / PGM / MVがGPUテキスチャとしてGUIへ届く経路（ネイティブ面へのswapchain blitと、一覧サムネの読み戻し）を追記した
- 本線のソースは毎マスターフレーム取り込み、MonitorとサムネのInputは更新間隔でGPUへ載せる
- OMT受信の品質判定は、開いている監視面を毎フレーム見る。Sceneをdirtyにしたときは、そのレイヤーも取り込む
- `sitemap-index.xml`と`robots.txt`を出し、ドキュメントフッターに最新GitHubリリースを表示する

Closes #126

## テスト計画
- [x] `cargo test --lib collect_frame_live_ids collect_live_ids`（本線と監視面、dirtyなSceneの単体テスト）
- [x] PRV/PGMに載っていないInput/Sceneタイルを複数開き、一覧サムネが設定した間隔で更新されること
- [x] そのうち1つをProgramに載せ、毎フレーム取り込まれること
- [x] Multiviewに載っているOMT入力をTAKE / Tバーし、受信品質が維持されること
- [x] 未使用Sceneのレイアウトを編集し、新しいレイヤーがすぐ出ること
- [ ] docsデプロイ後、https://mikanseilaboratory.github.io/eiviz/sitemap-index.xml と https://mikanseilaboratory.github.io/eiviz/robots.txt を開く
- [ ] フッターに最新のGitHubリリースタグが出ること
- [ ] Google Search ConsoleでURLプレフィックス `https://mikanseilaboratory.github.io/eiviz/` を追加し、`sitemap-index.xml`を送信する（orgオーナー、初回のみ）