### PR TITLE
Fix OMT send crash on VMX buffer overflow

### DIFF
--- a/mixer/Cargo.lock
+++ b/mixer/Cargo.lock
@@ -902,7 +902,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=2873431961ae222996c2125047ec9c7e9f635fe0#2873431961ae222996c2125047ec9c7e9f635fe0"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=23eab04d3374eb09840e6250d1da6d96f79e04f8#23eab04d3374eb09840e6250d1da6d96f79e04f8"
 dependencies = [
  "bytes",
  "mdns-sd",

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 bytemuck = { version = "1.25", features = ["derive"] }
 fontdue = "0.9"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "2873431961ae222996c2125047ec9c7e9f635fe0", features = ["wgpu"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "23eab04d3374eb09840e6250d1da6d96f79e04f8", features = ["wgpu"] }
 pollster = "0.4"
 raw-window-handle = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -256,6 +256,71 @@ fn dx12_omt_gpu_in_and_out() {
     mixer_destroy();
 }
 
+#[test]
+fn omt_gpu_send_1080p_rgba_does_not_overflow() {
+    use openmediatransport::{GpuVideoContext, VideoTextureMeta};
+    use std::sync::Arc;
+
+    let Some((_, _, device, queue)) = vmx::gpu::request_headless_device() else {
+        eprintln!("skip: no wgpu adapter");
+        return;
+    };
+    let ctx = GpuVideoContext {
+        device: Arc::new(device.clone()),
+        queue: Arc::new(queue.clone()),
+        gpu_lock: None,
+    };
+    let width = 1920u32;
+    let height = 1080u32;
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("eiviz omt 1080p rgba"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_DST
+            | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let mut pixels = vec![0u8; (width * height * 4) as usize];
+    for (i, b) in pixels.iter_mut().enumerate() {
+        *b = (i.wrapping_mul(1103515245).wrapping_add(12345) >> 16) as u8;
+    }
+    queue.write_texture(
+        texture.as_image_copy(),
+        &pixels,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(width * 4),
+            rows_per_image: Some(height),
+        },
+        texture.size(),
+    );
+
+    let mut sender = Sender::create("eiviz-1080p-gpu", FrameType::VIDEO).expect("sender");
+    sender.force_subscribe(true, false, false);
+    sender
+        .send_video_texture(
+            &ctx,
+            &texture,
+            VideoTextureMeta {
+                width,
+                height,
+                timestamp: 1,
+                frame_rate_n: 60,
+                frame_rate_d: 1,
+                ..Default::default()
+            },
+        )
+        .expect("1080p GPU OMT send");
+}
+
 fn scene_id(id: u64) -> u64 {
     SCENE_BASE | id
 }


### PR DESCRIPTION
## Summary
- High-entropy 1080p GPU encode exceeded the 1 MiB VMX save buffer and returned `BufferOverflow`, which the mixer treated as fatal
- Pin openmediatransport-rs to the fix that sizes the buffer from geometry and retries on overflow ([openmediatransport-rs#37](https://github.com/MikanseiLaboratory/openmediatransport-rs/pull/37))
- Add a noisy 1080p `Rgba8Unorm` GPU send regression test

Closes #135

## Test plan
- [x] `cargo test --test pipeline omt_gpu_send_1080p_rgba_does_not_overflow` failed before the pin and passes after
- [x] Start Eiviz.Host, connect a receiver to `eiviz-pgm`, receive 1920x1080 frames
- [x] Confirm `eiviz-mixer.log` has no `omt send texture: VMX error: buffer overflow` after the new host start
- [x] Toggle Settings → Outputs OMT Encode path GPU on a detailed Program (camera / bars) and confirm the host stays up