### PR TITLE
Accept UYVY-decoded Blue in the OMT fade finish check

### DIFF
--- a/mixer/tests/pipeline.rs
+++ b/mixer/tests/pipeline.rs
@@ -288,13 +288,9 @@ fn omt_program_shows_fade_during_auto() {
     while auto_started.elapsed() < Duration::from_millis(u64::from(AUTO_MS) + 200) {
         let _ = session.recv_video_timeout(Duration::from_millis(20));
     }
-    let after = wait_omt_until(
-        &session,
-        |sample| sample.1 > 160.0 && sample.0 < 80.0,
-        Duration::from_secs(2),
-    );
+    let after = wait_omt_until(&session, looks_blue, Duration::from_secs(2));
     assert!(
-        after.1 > 160.0 && after.0 < 80.0,
+        looks_blue(after),
         "program should finish on Blue, got r={} b={}",
         after.0,
         after.1
@@ -515,6 +511,11 @@ fn mean_red_blue(frame: &DecodedVideoFrame) -> (f32, f32) {
     }
     let count = count.max(1) as f32;
     (red as f32 / count, blue as f32 / count)
+}
+
+/// SRC_BLUE through UYVY pack/decode is not a clean (0, 255) primary.
+fn looks_blue(sample: (f32, f32)) -> bool {
+    sample.1 > 150.0 && sample.1 > sample.0 + 40.0
 }
 
 fn wait_omt_sample(session: &ReceiverSession, budget: Duration) -> (f32, f32) {


### PR DESCRIPTION
## Summary
- Release CI failed `omt_program_shows_fade_during_auto` on a finished Program frame of r=82 b=171. That is Blue after UYVY pack/decode, but the old `r < 80 && b > 160` gate treated it as a miss.
- Finish detection now uses chroma dominance (`b > 150` and `b > r + 40`), which still rejects a frozen Color/red Program.

## Test plan
- [x] `cargo test --test pipeline omt_program_shows_fade_during_auto`
- [ ] Windows CI `CI / Test and build (Windows x64)` is green
- [ ] After merge, retag `v0.2.0-beta.7` on main to publish the pre-release (`v0.2.0-beta.7` was deleted so this CI miss would not publish)
