### PR TITLE
Keep file videos playing when Output settings are applied

### DIFF
--- a/host/CommandQueue.cs
+++ b/host/CommandQueue.cs
@@ -35,7 +35,7 @@ internal sealed record ConnectOmtCommand(ulong SourceId, string Address, bool Us
 internal sealed record ConnectNdiCommand(ulong SourceId, string Address, uint FrameBufferFrames, NdiBandwidth Bandwidth) : MixerCommand;
 internal sealed record LiveSaveCommand(ulong SourceId, BandwidthSave SaveMode, bool KeepFullOnMultiview, OmtQuality? OmtQuality = null) : MixerCommand;
 internal sealed record LoadStillCommand(ulong SourceId, string Path) : MixerCommand;
-internal sealed record StartVideoCommand(ulong SourceId, string Path, bool Loop = true, bool Playing = true, uint FrameBufferFrames = 3) : MixerCommand;
+internal sealed record StartVideoCommand(ulong SourceId, string Path, bool Loop = true, bool Playing = true, uint FrameBufferFrames = 3, long PositionHns = 0) : MixerCommand;
 internal sealed record StartUvcCommand(ulong SourceId, string SymbolicLink, uint Width, uint Height, uint FpsNum, uint FpsDen, uint FrameBufferFrames = 3) : MixerCommand;
 internal sealed record PatchAuxCommand(ulong UnitId, MixingUnitEntry Unit) : MixerCommand;
 internal sealed record AddOutputCommand(OutputEntry Output) : MixerCommand;
@@ -393,6 +393,8 @@ internal sealed class CommandQueue : IAsyncDisposable
                     "Video start");
                 MixerNative.VideoSetLoop(video.SourceId, video.Loop ? 1u : 0u);
                 MixerNative.VideoSetPlaying(video.SourceId, video.Playing ? 1u : 0u);
+                if (video.PositionHns > 0)
+                    MixerNative.VideoSeek(video.SourceId, video.PositionHns);
                 break;
             case StartUvcCommand uvc:
                 MixerNative.ThrowIfFailed(

--- a/host/MainWindow.xaml.cs
+++ b/host/MainWindow.xaml.cs
@@ -1961,6 +1961,8 @@ public partial class MainWindow : Window
         var dialog = new SettingsWindow(_session) { Owner = this };
         if (dialog.ShowDialog() != true)
             return;
+        var restartMedia = _session.Settings.InternalColorFormat != dialog.Settings.InternalColorFormat
+            || _session.Settings.FrameBufferFrames != dialog.Settings.FrameBufferFrames;
         _session.Settings.MasterFpsNum = dialog.Settings.MasterFpsNum;
         _session.Settings.MasterFpsDen = dialog.Settings.MasterFpsDen;
         _session.Settings.DefaultWidth = dialog.Settings.DefaultWidth;
@@ -2007,27 +2009,38 @@ public partial class MainWindow : Window
         foreach (var window in _multiviews)
             window.SyncPresentInterval();
         PushScenePresentIntervals();
-        RestartMediaPumps();
+        MixerNative.VideoFormat = _session.Settings.InternalColorFormat == InternalColorFormat.Bgra
+            ? MixerNative.FormatBgra
+            : MixerNative.FormatUyvy;
+        if (restartMedia)
+            RestartMediaPumps();
         ApplyOutputs(dialog.Outputs);
         RebuildMeters();
     }
 
     private void RestartMediaPumps()
     {
-        MixerNative.VideoFormat = _session.Settings.InternalColorFormat == InternalColorFormat.Bgra
-            ? MixerNative.FormatBgra
-            : MixerNative.FormatUyvy;
         foreach (var input in _session.Inputs)
         {
             if (string.IsNullOrWhiteSpace(input.PathOrAddress))
                 continue;
             if (input.Kind == InputKind.Video)
+            {
+                var playing = input.VideoStartsPlaying;
+                var position = 0L;
+                if (TryVideoInfo(input.Id, out var info))
+                {
+                    playing = info.Playing != 0;
+                    position = info.PositionHns;
+                }
                 Commands.TryEnqueue(new StartVideoCommand(
                     input.Id,
                     input.PathOrAddress,
                     input.VideoLoop,
-                    input.VideoStartsPlaying,
-                    input.FrameBufferFrames));
+                    playing,
+                    input.FrameBufferFrames,
+                    position));
+            }
             else if (input.Kind == InputKind.Uvc)
                 Commands.TryEnqueue(new StartUvcCommand(input.Id, input.PathOrAddress, input.CaptureWidth, input.CaptureHeight, input.CaptureFpsNum, input.CaptureFpsDen, input.FrameBufferFrames));
         }

--- a/host/VideoTransport.cs
+++ b/host/VideoTransport.cs
@@ -10,7 +10,8 @@ internal sealed class VideoTransport
 
     public void Tick(Session session, IEnumerable<ulong> previewWindows)
     {
-        var roles = Collect(session, previewWindows);
+        if (!TryCollect(session, previewWindows, out var roles))
+            return;
         foreach (var input in session.Inputs)
         {
             if (input.Kind != InputKind.Video)
@@ -52,9 +53,10 @@ internal sealed class VideoTransport
             _ => false
         };
 
-    internal static Dictionary<ulong, VideoRoles> Collect(Session session, IEnumerable<ulong> previewWindows)
+    internal static bool TryCollect(Session session, IEnumerable<ulong> previewWindows, out Dictionary<ulong, VideoRoles> roles)
     {
-        var roles = new Dictionary<ulong, VideoRoles>();
+        roles = new Dictionary<ulong, VideoRoles>();
+        var unitsRead = 0;
         foreach (var unit in session.Units)
         {
             UnitState state = default;
@@ -63,6 +65,7 @@ internal sealed class VideoTransport
                 if (MixerNative.GetUnitState(unit.Id, &state) != 0)
                     continue;
             }
+            unitsRead++;
             Mark(session, roles, state.ProgramSource, program: true, preview: false);
             Mark(session, roles, state.PreviewSource, program: false, preview: true);
             if (state.Mix > 0.001f)
@@ -75,7 +78,7 @@ internal sealed class VideoTransport
         }
         foreach (var id in previewWindows)
             Mark(session, roles, id, program: false, preview: true);
-        return roles;
+        return session.Units.Count == 0 || unitsRead > 0;
     }
 
     private static void Mark(Session session, Dictionary<ulong, VideoRoles> roles, ulong id, bool program, bool preview)

--- a/mac/Sources/EivizMac/MixerController.swift
+++ b/mac/Sources/EivizMac/MixerController.swift
@@ -1403,9 +1403,11 @@ final class MixerController: ObservableObject {
 
     private func tickVideoTransport() {
         var roles: [UInt64: (program: Bool, preview: Bool)] = [:]
+        var unitsRead = 0
         for unit in session.units {
             var state = MixerFFI.emptyState()
-            _ = mixer_unit_get_state(unit.id, &state)
+            guard mixer_unit_get_state(unit.id, &state) == EIVIZ_OK else { continue }
+            unitsRead += 1
             markVideoRole(&roles, state.program_source, program: true, preview: false)
             markVideoRole(&roles, state.preview_source, program: false, preview: true)
             if state.mix > 0.001 {
@@ -1415,6 +1417,9 @@ final class MixerController: ObservableObject {
             for slot in unit.overlays where slot.enabled && slot.sceneGpuId != 0 {
                 markVideoRole(&roles, slot.sceneGpuId, program: true, preview: false)
             }
+        }
+        if !session.units.isEmpty && unitsRead == 0 {
+            return
         }
         for id in inputPreviewWindows.keys {
             markVideoRole(&roles, id, program: false, preview: true)

--- a/mixer/src/media.rs
+++ b/mixer/src/media.rs
@@ -243,7 +243,7 @@ fn run_loop(
         let mut seek_base = 0i64;
         let mut clock_start = Instant::now();
         let mut gpu_warned = false;
-        let mut need_frame = false;
+        let mut need_frame = !capture;
         let mut was_playing = false;
         loop {
             if stop.load(Ordering::Relaxed) {

--- a/mixer/src/media_macos.rs
+++ b/mixer/src/media_macos.rs
@@ -332,7 +332,7 @@ fn run_loop(
         let mut clock_pts = -1i64;
         let mut seek_base = 0i64;
         let mut clock_start = Instant::now();
-        let mut need_frame = false;
+        let mut need_frame = !capture;
         let mut was_playing = false;
         loop {
             if stop.load(Ordering::Relaxed) {


### PR DESCRIPTION
## Summary
- Output設定の適用だけでは動画ポンプを作り直さないようにし、再生中の動画が止まらないようにしました
- 色形式やフレームバッファ変更で再起動が必要な場合は、再生状態と位置を引き継ぎます
- 再生開始前でも最初の1フレームをSceneに出し、Mixerが忙しいときは誤った自動停止をしないようにしました

Closes #144

## Test plan
- [x] 動画を再生した状態でSettingsのOutputsだけを変えてApplyし、再生が続いていること
- [x] ユーザーが一時停止した動画は、Output適用後も停止のままであること
- [x] Play WhenがActive/Previewの動画をSceneに置き、再生前に最初のフレームが見えること
- [x] 内部色形式またはフレームバッファを変えたApplyでは、再生位置と再生/停止が維持されること