### PR TITLE
Stamp hosts as 0.2.0

### DIFF
--- a/host/Eiviz.Host.csproj
+++ b/host/Eiviz.Host.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
     <Version>0.2.0</Version>
-    <InformationalVersion>0.2.0-beta.3</InformationalVersion>
+    <InformationalVersion>0.2.0</InformationalVersion>
     <MixerProject>$(MSBuildThisFileDirectory)..\mixer</MixerProject>
     <MixerLibrary>$(MixerProject)\target\release\eiviz_mixer.dll</MixerLibrary>
   </PropertyGroup>

--- a/mac/Sources/EivizMac/HostVersion.swift
+++ b/mac/Sources/EivizMac/HostVersion.swift
@@ -7,6 +7,6 @@ enum HostVersion {
         {
             return version
         }
-        return "0.2.0-beta.3"
+        return "0.2.0"
     }
 }

--- a/mac/Sources/EivizMac/Info.plist
+++ b/mac/Sources/EivizMac/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0-beta.3</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.0-beta.3</string>
+	<string>0.2.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
## 概要
- About表示とmacOSバンドルのバージョンを `0.2.0-beta.3` から `0.2.0` に揃える
- 対象は Windows の `InformationalVersion`、macOS の `Info.plist`、および HostVersion のフォールバック

## 確認手順
- [ ] Windows About が Version 0.2.0 と表示される
- [ ] macOS About が Version 0.2.0 と表示される
- [ ] CI が通る
