### PR TITLE
Fix Mixing Unit scene-filter radio visibility

### DIFF
--- a/host/App.xaml
+++ b/host/App.xaml
@@ -35,6 +35,98 @@
                 <Setter Property="Background" Value="{DynamicResource ListBackground}"/>
                 <Setter Property="Foreground" Value="{DynamicResource TextForeground}"/>
             </Style>
+            <Style TargetType="RadioButton">
+                <Setter Property="Foreground" Value="{DynamicResource TextForeground}"/>
+                <Setter Property="Background" Value="{DynamicResource FieldBackground}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorder}"/>
+                <Setter Property="Padding" Value="6,0,0,0"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <BulletDecorator Background="Transparent" SnapsToDevicePixels="True">
+                                <BulletDecorator.Bullet>
+                                    <Grid Width="16" Height="16">
+                                        <Ellipse x:Name="outer"
+                                                 Stroke="{TemplateBinding BorderBrush}"
+                                                 StrokeThickness="1"
+                                                 Fill="{TemplateBinding Background}"/>
+                                        <Ellipse x:Name="optionMark"
+                                                 Width="8" Height="8"
+                                                 HorizontalAlignment="Center"
+                                                 VerticalAlignment="Center"
+                                                 Fill="{DynamicResource TextForeground}"
+                                                 Visibility="Collapsed"/>
+                                    </Grid>
+                                </BulletDecorator.Bullet>
+                                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  HorizontalAlignment="Left"
+                                                  RecognizesAccessKey="True"/>
+                            </BulletDecorator>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="optionMark" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="outer" Property="Stroke" Value="{DynamicResource TextForeground}"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.5"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style TargetType="CheckBox">
+                <Setter Property="Foreground" Value="{DynamicResource TextForeground}"/>
+                <Setter Property="Background" Value="{DynamicResource FieldBackground}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorder}"/>
+                <Setter Property="Padding" Value="6,0,0,0"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="CheckBox">
+                            <BulletDecorator Background="Transparent" SnapsToDevicePixels="True">
+                                <BulletDecorator.Bullet>
+                                    <Grid Width="16" Height="16">
+                                        <Border x:Name="checkBorder"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="2"/>
+                                        <Path x:Name="optionMark"
+                                              Data="M3,8 L6.5,11.5 L13,4"
+                                              Stroke="{DynamicResource TextForeground}"
+                                              StrokeThickness="1.8"
+                                              StrokeStartLineCap="Round"
+                                              StrokeEndLineCap="Round"
+                                              StrokeLineJoin="Round"
+                                              Visibility="Collapsed"/>
+                                    </Grid>
+                                </BulletDecorator.Bullet>
+                                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  RecognizesAccessKey="True"/>
+                            </BulletDecorator>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="optionMark" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="checkBorder" Property="BorderBrush" Value="{DynamicResource TextForeground}"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.5"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/host/Dialogs/SwitcherScenesWindow.xaml
+++ b/host/Dialogs/SwitcherScenesWindow.xaml
@@ -6,28 +6,10 @@
         Background="#2B2B2B" Foreground="#EEEEEE"
         ResizeMode="NoResize">
     <Window.Resources>
-        <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#222222"/>
-        <SolidColorBrush x:Key="{x:Static SystemColors.ControlLightBrushKey}" Color="#222222"/>
-        <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}" Color="#2B2B2B"/>
-        <Style TargetType="RadioButton">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="#EEEEEE"/>
-            <Setter Property="BorderBrush" Value="#555555"/>
-        </Style>
         <Style TargetType="ListBox">
             <Setter Property="Background" Value="#222222"/>
             <Setter Property="Foreground" Value="#EEEEEE"/>
             <Setter Property="BorderBrush" Value="#555555"/>
-            <Style.Triggers>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Background" Value="#222222"/>
-                    <Setter Property="Foreground" Value="#EEEEEE"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-        <Style TargetType="CheckBox">
-            <Setter Property="Foreground" Value="#F5F5F5"/>
-            <Setter Property="Background" Value="Transparent"/>
         </Style>
     </Window.Resources>
     <DockPanel Margin="16">


### PR DESCRIPTION
## Summary
- Mixing Unit の「シーン…」ダイアログで、ダーク背景向けのラジオ／チェックテンプレートを使い、選択マークが見えるようにした
- 透明背景と SystemColors 上書きをやめ、内側のマークは `IsChecked` で Visibility を切り替える

## Test plan
- [x] Mixing Unit の Switcher を開き、「シーン…」を開く
- [x] 「すべてのシーン」「選択したシーンだけ」「選択したシーンを隠す」のラジオ内側が選択時に見える
- [x] シーン一覧のチェックマークも同様に見える
- [x] 各ラジオを切り替えて一覧の有効／無効が変わる

Fixes #168