### PR TITLE
Stamp hosts as 0.3.0-alpha.1

### DIFF
--- a/hosts/macos/Sources/EivizMac/HostVersion.swift
+++ b/hosts/macos/Sources/EivizMac/HostVersion.swift
@@ -7,6 +7,6 @@ enum HostVersion {
         {
             return version
         }
-        return "0.2.1-beta.1"
+        return "0.3.0-alpha.1"
     }
 }

--- a/hosts/macos/Sources/EivizMac/Info-Remote.plist
+++ b/hosts/macos/Sources/EivizMac/Info-Remote.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1-beta.1</string>
+	<string>0.3.0-alpha.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.1-beta.1</string>
+	<string>0.3.0-alpha.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSCameraUsageDescription</key>

--- a/hosts/macos/Sources/EivizMac/Info.plist
+++ b/hosts/macos/Sources/EivizMac/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1-beta.1</string>
+	<string>0.3.0-alpha.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.1-beta.1</string>
+	<string>0.3.0-alpha.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSCameraUsageDescription</key>

--- a/hosts/win32/Eiviz.Host.csproj
+++ b/hosts/win32/Eiviz.Host.csproj
@@ -11,8 +11,8 @@
     <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
-    <Version>0.2.1-beta.1</Version>
-    <InformationalVersion>0.2.1-beta.1</InformationalVersion>
+    <Version>0.3.0-alpha.1</Version>
+    <InformationalVersion>0.3.0-alpha.1</InformationalVersion>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
     <MixerLibrary>$(RepoRoot)target\release\eiviz_mixer.dll</MixerLibrary>
     <RemoteLibrary>$(RepoRoot)target\release\eiviz_remote.dll</RemoteLibrary>

--- a/hosts/win32/Eiviz.Remote.csproj
+++ b/hosts/win32/Eiviz.Remote.csproj
@@ -17,8 +17,8 @@
     <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
-    <Version>0.2.1-beta.1</Version>
-    <InformationalVersion>0.2.1-beta.1</InformationalVersion>
+    <Version>0.3.0-alpha.1</Version>
+    <InformationalVersion>0.3.0-alpha.1</InformationalVersion>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
     <MixerLibrary>$(RepoRoot)target\release\eiviz_mixer.dll</MixerLibrary>
     <RemoteLibrary>$(RepoRoot)target\release\eiviz_remote.dll</RemoteLibrary>

--- a/hosts/win32/HostVersion.cs
+++ b/hosts/win32/HostVersion.cs
@@ -16,7 +16,7 @@ internal static class HostVersion
                 var plus = info.IndexOf('+');
                 return plus < 0 ? info.Trim() : info[..plus].Trim();
             }
-            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.2.1-beta.1";
+            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.3.0-alpha.1";
         }
     }
 }

--- a/mixer/src/vmix_tcp.rs
+++ b/mixer/src/vmix_tcp.rs
@@ -685,8 +685,8 @@ mod tests {
 
     #[test]
     fn xmltext_reads_version_and_input_title() {
-        let xml = r#"<vmix><version>0.2.1-beta.1</version><inputs><input key="a" number="1" title="Scene 1"></input></inputs></vmix>"#;
-        assert_eq!(xml_text("vmix/version", xml).unwrap(), "0.2.1-beta.1");
+        let xml = r#"<vmix><version>0.3.0-alpha.1</version><inputs><input key="a" number="1" title="Scene 1"></input></inputs></vmix>"#;
+        assert_eq!(xml_text("vmix/version", xml).unwrap(), "0.3.0-alpha.1");
         assert_eq!(
             xml_text("vmix/inputs/input[1]/@title", xml).unwrap(),
             "Scene 1"

--- a/mixer/src/vmix_xml.rs
+++ b/mixer/src/vmix_xml.rs
@@ -10,7 +10,7 @@ use vmix_core::{
 use crate::abi::{DURATION_FRAMES, DURATION_MS, SCENE_BASE, TRANSITION_FADE};
 use crate::session::{Document, InputKind, TransitionPreset, UnitDto};
 
-pub(crate) const VERSION: &str = "0.2.1-beta.1";
+pub(crate) const VERSION: &str = "0.3.0-alpha.1";
 const EDITION: &str = "eiviz";
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Windows/macOSホストとvMix XMLの表示バージョンを `0.2.1-beta.1` から `0.3.0-alpha.1` に揃える
- マージ後に `v0.3.0-alpha.1` タグをpushし、Releaseワークフローでプレリリースを作成する

## Test plan
- [x] CI（Windows/macOS）が緑であること
- [x] Windows About が Version 0.3.0-alpha.1 と表示されること
- [x] macOS About が Version 0.3.0-alpha.1 と表示されること
- [x] vMix互換XMLの `<version>` が 0.3.0-alpha.1 であること
