### PR TITLE
Stamp hosts as 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "eiviz-api"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 dependencies = [
  "base64",
  "eiviz-control",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "eiviz-control"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "eiviz-headless"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "eiviz-api",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "eiviz_mixer"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 dependencies = [
  "ash",
  "base64",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "eiviz_remote"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 dependencies = [
  "eiviz-api",
  "eiviz-control",

--- a/crates/eiviz-api/Cargo.toml
+++ b/crates/eiviz-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiviz-api"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/eiviz-control/Cargo.toml
+++ b/crates/eiviz-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiviz-control"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/eiviz-remote/Cargo.toml
+++ b/crates/eiviz-remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiviz_remote"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/headless/Cargo.toml
+++ b/headless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiviz-headless"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/hosts/macos/Sources/EivizMac/HostVersion.swift
+++ b/hosts/macos/Sources/EivizMac/HostVersion.swift
@@ -7,6 +7,6 @@ enum HostVersion {
         {
             return version
         }
-        return "0.3.0-alpha.2"
+        return "0.3.0"
     }
 }

--- a/hosts/macos/Sources/EivizMac/Info-Remote.plist
+++ b/hosts/macos/Sources/EivizMac/Info-Remote.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0-alpha.2</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.3.0-alpha.2</string>
+	<string>0.3.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSCameraUsageDescription</key>

--- a/hosts/macos/Sources/EivizMac/Info.plist
+++ b/hosts/macos/Sources/EivizMac/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0-alpha.2</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.3.0-alpha.2</string>
+	<string>0.3.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSCameraUsageDescription</key>

--- a/hosts/win32/Eiviz.Host.csproj
+++ b/hosts/win32/Eiviz.Host.csproj
@@ -11,8 +11,8 @@
     <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
-    <Version>0.3.0-alpha.2</Version>
-    <InformationalVersion>0.3.0-alpha.2</InformationalVersion>
+    <Version>0.3.0</Version>
+    <InformationalVersion>0.3.0</InformationalVersion>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
     <MixerLibrary>$(RepoRoot)target\release\eiviz_mixer.dll</MixerLibrary>
     <RemoteLibrary>$(RepoRoot)target\release\eiviz_remote.dll</RemoteLibrary>

--- a/hosts/win32/Eiviz.Remote.csproj
+++ b/hosts/win32/Eiviz.Remote.csproj
@@ -17,8 +17,8 @@
     <Authors>Shugo Kawamura; Mikansei Laboratory</Authors>
     <Copyright>Copyright 2026 Shugo Kawamura / Mikansei Laboratory</Copyright>
     <PackageLicenseExpression>PolyForm-Shield-1.0.0</PackageLicenseExpression>
-    <Version>0.3.0-alpha.2</Version>
-    <InformationalVersion>0.3.0-alpha.2</InformationalVersion>
+    <Version>0.3.0</Version>
+    <InformationalVersion>0.3.0</InformationalVersion>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
     <MixerLibrary>$(RepoRoot)target\release\eiviz_mixer.dll</MixerLibrary>
     <RemoteLibrary>$(RepoRoot)target\release\eiviz_remote.dll</RemoteLibrary>

--- a/hosts/win32/HostVersion.cs
+++ b/hosts/win32/HostVersion.cs
@@ -16,7 +16,7 @@ internal static class HostVersion
                 var plus = info.IndexOf('+');
                 return plus < 0 ? info.Trim() : info[..plus].Trim();
             }
-            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.3.0-alpha.2";
+            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.3.0";
         }
     }
 }

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiviz_mixer"
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/mixer/src/vmix_tcp.rs
+++ b/mixer/src/vmix_tcp.rs
@@ -685,8 +685,8 @@ mod tests {
 
     #[test]
     fn xmltext_reads_version_and_input_title() {
-        let xml = r#"<vmix><version>0.3.0-alpha.2</version><inputs><input key="a" number="1" title="Scene 1"></input></inputs></vmix>"#;
-        assert_eq!(xml_text("vmix/version", xml).unwrap(), "0.3.0-alpha.2");
+        let xml = r#"<vmix><version>0.3.0</version><inputs><input key="a" number="1" title="Scene 1"></input></inputs></vmix>"#;
+        assert_eq!(xml_text("vmix/version", xml).unwrap(), "0.3.0");
         assert_eq!(
             xml_text("vmix/inputs/input[1]/@title", xml).unwrap(),
             "Scene 1"

--- a/mixer/src/vmix_xml.rs
+++ b/mixer/src/vmix_xml.rs
@@ -10,7 +10,7 @@ use vmix_core::{
 use crate::abi::{DURATION_FRAMES, DURATION_MS, SCENE_BASE, TRANSITION_FADE};
 use crate::session::{Document, InputKind, TransitionPreset, UnitDto};
 
-pub(crate) const VERSION: &str = "0.3.0-alpha.2";
+pub(crate) const VERSION: &str = "0.3.0";
 const EDITION: &str = "eiviz";
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Windows/macOSホスト、Cargoクレート、vMix XMLの表示バージョンを`0.3.0-alpha.2`から`0.3.0`に揃える
- マージ後に`v0.3.0`タグをpushし、Releaseワークフローで正式リリースを作成する

## Test plan
- [ ] CI（Windows/macOS/Linux）が緑であること
- [ ] Windows AboutがVersion 0.3.0と表示されること
- [ ] macOS AboutがVersion 0.3.0と表示されること
- [ ] vMix互換XMLの`<version>`が0.3.0であること