### PR TITLE
Harden vMix-compatible HTTP API and session mutation/save paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "subtle",
  "thiserror 2.0.20",
  "tiny_http",
  "tokio",

--- a/crates/eiviz-control/src/session/file.rs
+++ b/crates/eiviz-control/src/session/file.rs
@@ -295,9 +295,6 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
     }
     let tmp = tmp_path(path);
     std::fs::write(&tmp, bytes).map_err(|error| error.to_string())?;
-    if path.exists() {
-        std::fs::remove_file(path).map_err(|error| error.to_string())?;
-    }
     match std::fs::rename(&tmp, path) {
         Ok(()) => Ok(()),
         Err(error) => {

--- a/crates/eiviz-control/src/session/mutate.rs
+++ b/crates/eiviz-control/src/session/mutate.rs
@@ -4,6 +4,12 @@ use crate::command::SessionMutation;
 use crate::error::{ControlError, ControlResult};
 use crate::session::{Document, InputDto, InputKind, MultiviewDto, SceneDto, UnitDto};
 
+/// Overlay slots are a small fixed-size UI concept; an index beyond this would
+/// only ever arrive from a malformed or hostile request, and resizing the
+/// backing `Vec` to that index would let a caller force an arbitrarily large
+/// allocation (e.g. `index: u32::MAX`).
+const MAX_OVERLAY_SLOTS: usize = 64;
+
 pub fn apply(document: &mut Document, mutation: SessionMutation) -> ControlResult<()> {
     match mutation {
         SessionMutation::UpsertInput { input } => upsert_input(document, *input),
@@ -55,12 +61,17 @@ pub fn apply(document: &mut Document, mutation: SessionMutation) -> ControlResul
             index,
             slot,
         } => {
+            let index = index as usize;
+            if index >= MAX_OVERLAY_SLOTS {
+                return Err(ControlError::invalid(format!(
+                    "overlay slot index {index} exceeds the maximum of {MAX_OVERLAY_SLOTS}"
+                )));
+            }
             let unit = document
                 .units
                 .iter_mut()
                 .find(|item| item.id == unit_id)
                 .ok_or_else(|| ControlError::not_found(format!("unit {unit_id}")))?;
-            let index = index as usize;
             if index >= unit.overlays.len() {
                 unit.overlays.resize(
                     index + 1,
@@ -375,6 +386,42 @@ mod tests {
         );
         assert_eq!(added.switcher_scene_ids, vec![1]);
         assert_eq!(doc.next_unit_id, 3);
+    }
+
+    #[test]
+    fn set_overlay_slot_rejects_out_of_range_index() {
+        let mut doc = bars();
+        let err = apply(
+            &mut doc,
+            SessionMutation::SetOverlaySlot {
+                unit_id: 1,
+                index: u32::MAX,
+                slot: Box::new(crate::session::OverlaySlot::default()),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ControlError::InvalidArgument { .. }));
+        assert!(doc.units[0].overlays.is_empty());
+    }
+
+    #[test]
+    fn set_overlay_slot_within_range_resizes_and_sets() {
+        let mut doc = bars();
+        apply(
+            &mut doc,
+            SessionMutation::SetOverlaySlot {
+                unit_id: 1,
+                index: 2,
+                slot: Box::new(crate::session::OverlaySlot {
+                    scene_gpu_id: 7,
+                    enabled: true,
+                    ..crate::session::OverlaySlot::default()
+                }),
+            },
+        )
+        .unwrap();
+        assert_eq!(doc.units[0].overlays.len(), 3);
+        assert_eq!(doc.units[0].overlays[2].scene_gpu_id, 7);
     }
 
     #[test]

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -25,6 +25,7 @@ openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatra
 pollster = "0.4"
 raw-window-handle = "0.6"
 base64 = "0.22"
+subtle.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/mixer/src/vmix_api.rs
+++ b/mixer/src/vmix_api.rs
@@ -98,14 +98,16 @@ pub fn configure(enabled: bool, port: u32, user: &str, pass: &str) -> i32 {
         return OK;
     }
     slot.listen_owner = None;
+    let want_open_bind = !(config.user.is_empty() && config.pass.is_empty());
+    let bind_host = if want_open_bind { "0.0.0.0" } else { "127.0.0.1" };
     let reuse = slot
         .server
         .as_ref()
         .and_then(|server| server.server_addr().to_ip())
-        .is_some_and(|addr| addr.port() == config.port);
+        .is_some_and(|addr| addr.port() == config.port && !addr.ip().is_loopback() == want_open_bind);
     if !reuse {
         slot.server = None;
-        let addr = format!("0.0.0.0:{}", config.port);
+        let addr = format!("{bind_host}:{}", config.port);
         match Server::http(&addr) {
             Ok(server) => {
                 crate::diag::http_info(&format!("http listen {addr}"));
@@ -126,7 +128,7 @@ pub fn configure(enabled: bool, port: u32, user: &str, pass: &str) -> i32 {
             }
         }
     } else {
-        crate::diag::http_info(&format!("http restart 0.0.0.0:{}", config.port));
+        crate::diag::http_info(&format!("http restart {bind_host}:{}", config.port));
     }
     let server = slot.server.clone().expect("http listener");
     match spawn_worker(server, Arc::clone(&slot.stop), config) {
@@ -517,8 +519,19 @@ fn check_auth(request: &Request, config: &ApiConfig) -> bool {
                 .value
                 .as_str()
                 .strip_prefix("Basic ")
-                .is_some_and(|token| token.trim() == expected)
+                .is_some_and(|token| constant_time_eq(token.trim(), &expected))
     })
+}
+
+/// Constant-time string comparison. A plain `==` here would let a network
+/// attacker recover a configured Basic-Auth credential byte-by-byte via
+/// response timing (this project's own `crates/eiviz-api/src/auth.rs`
+/// already uses `subtle::ConstantTimeEq` for the analogous check on its
+/// WebSocket control API -- this brings the vMix-compatible HTTP API's
+/// independent auth implementation up to the same standard).
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    use subtle::ConstantTimeEq;
+    a.len() == b.len() && a.as_bytes().ct_eq(b.as_bytes()).into()
 }
 
 fn is_api_path(path: &str) -> bool {
@@ -545,9 +558,18 @@ pub(crate) fn parse_query(query: &str) -> HashMap<String, String> {
     map
 }
 
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn url_decode(input: &str) -> String {
-    let mut out = Vec::with_capacity(input.len());
     let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
@@ -556,13 +578,15 @@ fn url_decode(input: &str) -> String {
                 i += 1;
             }
             b'%' if i + 2 < bytes.len() => {
-                let hex = &input[i + 1..i + 3];
-                if let Ok(value) = u8::from_str_radix(hex, 16) {
-                    out.push(value);
-                    i += 3;
-                } else {
-                    out.push(bytes[i]);
-                    i += 1;
+                match (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
+                    (Some(hi), Some(lo)) => {
+                        out.push((hi << 4) | lo);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
                 }
             }
             other => {
@@ -634,6 +658,63 @@ fn read_cstr(ptr: *const c_char) -> String {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn url_decode_does_not_panic_on_percent_before_multibyte_boundary() {
+        // '%' followed by '1' and the first byte of a 3-byte UTF-8 character
+        // (`あ`) used to be sliced with a raw byte range (`&input[i+1..i+3]`),
+        // which panics because index 3 falls inside `あ`'s byte sequence.
+        let input = "%1あ";
+        let decoded = url_decode(input);
+        assert_eq!(decoded, "%1あ");
+    }
+
+    #[test]
+    fn url_decode_decodes_percent_encoded_multibyte_utf8() {
+        // "%E3%81%82" is the UTF-8 encoding of `あ`.
+        assert_eq!(url_decode("%E3%81%82"), "あ");
+    }
+
+    #[test]
+    fn constant_time_eq_matches_string_equality() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "wrong"));
+        assert!(!constant_time_eq("secret", "secrets"));
+    }
+
+    #[test]
+    #[serial(mixer)]
+    fn configure_without_credentials_binds_loopback_only() {
+        let port = 18722;
+        assert_eq!(configure(true, port, "", ""), crate::abi::OK);
+        std::thread::sleep(Duration::from_millis(80));
+        let bound_ip = {
+            let slot = api_slot().lock().unwrap();
+            slot.server
+                .as_ref()
+                .and_then(|server| server.server_addr().to_ip())
+                .map(|addr| addr.ip())
+        };
+        assert_eq!(bound_ip, Some(std::net::IpAddr::from([127, 0, 0, 1])));
+        shutdown();
+    }
+
+    #[test]
+    #[serial(mixer)]
+    fn configure_with_credentials_binds_all_interfaces() {
+        let port = 18723;
+        assert_eq!(configure(true, port, "user", "secret"), crate::abi::OK);
+        std::thread::sleep(Duration::from_millis(80));
+        let bound_ip = {
+            let slot = api_slot().lock().unwrap();
+            slot.server
+                .as_ref()
+                .and_then(|server| server.server_addr().to_ip())
+                .map(|addr| addr.ip())
+        };
+        assert_eq!(bound_ip, Some(std::net::IpAddr::from([0, 0, 0, 0])));
+        shutdown();
+    }
 
     #[test]
     fn query_and_path() {


### PR DESCRIPTION
- vmix_api: use constant-time comparison for Basic-Auth token check to close a timing side-channel (mirrors eiviz-api's existing use of subtle::ConstantTimeEq for the native WS control API).
- vmix_api: bind to 127.0.0.1 instead of 0.0.0.0 when no user/pass is configured, since check_auth allows all requests through in that case and native_ws already applies the same loopback-only default.
- vmix_api: rewrite url_decode to operate purely on byte offsets instead of slicing the &str, fixing a panic when a '%' precedes a multi-byte UTF-8 character whose bytes don't land on a char boundary at the old fixed offset.
- eiviz-control::session::mutate: reject SetOverlaySlot indices above a small fixed cap instead of resizing the overlay Vec to an attacker-controlled size (e.g. u32::MAX).
- eiviz-control::session::file: drop the redundant remove_file before rename in atomic_write; fs::rename already replaces the destination atomically, and the extra step left a window where a crash between the two calls would destroy the existing file with nothing to replace it.
