### PR TITLE
chore: bump openmediatransport-rs and vmx-rs for fused GPU/CPU encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=413667f50ad45de139e5e063875047043a89cba4#413667f50ad45de139e5e063875047043a89cba4"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=9df655741fa35b8662af09cc4055b32e46c3d449#9df655741fa35b8662af09cc4055b32e46c3d449"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=5d9381745745870143cd7b477f0c5649accec7f7#5d9381745745870143cd7b477f0c5649accec7f7"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2#2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=2e57ca89e0af4ca9f4e9642c72f26c0d0b1eef64#2e57ca89e0af4ca9f4e9642c72f26c0d0b1eef64"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=413667f50ad45de139e5e063875047043a89cba4#413667f50ad45de139e5e063875047043a89cba4"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=e6cccd45bf6bb0fb6b0617ccc55c74ea4a03c657#e6cccd45bf6bb0fb6b0617ccc55c74ea4a03c657"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=5d9381745745870143cd7b477f0c5649accec7f7#5d9381745745870143cd7b477f0c5649accec7f7"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=9df655741fa35b8662af09cc4055b32e46c3d449#9df655741fa35b8662af09cc4055b32e46c3d449"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=7711da45e2ed83330c2e1fced06c5d1673e4d502#7711da45e2ed83330c2e1fced06c5d1673e4d502"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2#2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=b9a0fd19226e3e2ebf4041a2b119b855e71d9ca3#b9a0fd19226e3e2ebf4041a2b119b855e71d9ca3"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/mixer/Cargo.lock
+++ b/mixer/Cargo.lock
@@ -929,7 +929,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=9df655741fa35b8662af09cc4055b32e46c3d449#9df655741fa35b8662af09cc4055b32e46c3d449"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=7711da45e2ed83330c2e1fced06c5d1673e4d502#7711da45e2ed83330c2e1fced06c5d1673e4d502"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2#2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=b9a0fd19226e3e2ebf4041a2b119b855e71d9ca3#b9a0fd19226e3e2ebf4041a2b119b855e71d9ca3"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/mixer/Cargo.lock
+++ b/mixer/Cargo.lock
@@ -929,7 +929,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=2e57ca89e0af4ca9f4e9642c72f26c0d0b1eef64#2e57ca89e0af4ca9f4e9642c72f26c0d0b1eef64"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=413667f50ad45de139e5e063875047043a89cba4#413667f50ad45de139e5e063875047043a89cba4"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=e6cccd45bf6bb0fb6b0617ccc55c74ea4a03c657#e6cccd45bf6bb0fb6b0617ccc55c74ea4a03c657"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=5d9381745745870143cd7b477f0c5649accec7f7#5d9381745745870143cd7b477f0c5649accec7f7"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/mixer/Cargo.lock
+++ b/mixer/Cargo.lock
@@ -929,7 +929,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=413667f50ad45de139e5e063875047043a89cba4#413667f50ad45de139e5e063875047043a89cba4"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=9df655741fa35b8662af09cc4055b32e46c3d449#9df655741fa35b8662af09cc4055b32e46c3d449"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=5d9381745745870143cd7b477f0c5649accec7f7#5d9381745745870143cd7b477f0c5649accec7f7"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs?rev=2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2#2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2"
 dependencies = [
  "bytemuck",
  "pollster",

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -21,7 +21,7 @@ tokio.workspace = true
 bytemuck = { version = "1.25", features = ["derive"] }
 fontdue = "0.9"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "413667f50ad45de139e5e063875047043a89cba4", features = ["wgpu"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "9df655741fa35b8662af09cc4055b32e46c3d449", features = ["wgpu"] }
 pollster = "0.4"
 raw-window-handle = "0.6"
 base64 = "0.22"
@@ -30,7 +30,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tiny_http = "0.12"
 vmix-core = { git = "https://github.com/MikanseiLaboratory/vmix-rs", features = ["xml", "std"] }
-vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "5d9381745745870143cd7b477f0c5649accec7f7" }
+vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2" }
 wgpu = { version = "30.0.1", default-features = false, features = ["std", "wgsl", "parking_lot"] }
 naga = { version = "30.0.1", default-features = false, features = ["wgsl-in"] }
 

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -21,7 +21,7 @@ tokio.workspace = true
 bytemuck = { version = "1.25", features = ["derive"] }
 fontdue = "0.9"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "9df655741fa35b8662af09cc4055b32e46c3d449", features = ["wgpu"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "7711da45e2ed83330c2e1fced06c5d1673e4d502", features = ["wgpu"] }
 pollster = "0.4"
 raw-window-handle = "0.6"
 base64 = "0.22"
@@ -30,7 +30,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tiny_http = "0.12"
 vmix-core = { git = "https://github.com/MikanseiLaboratory/vmix-rs", features = ["xml", "std"] }
-vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "2780ad7d3441e9cc53cbbaef90f1c87c3c76fcc2" }
+vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "b9a0fd19226e3e2ebf4041a2b119b855e71d9ca3" }
 wgpu = { version = "30.0.1", default-features = false, features = ["std", "wgsl", "parking_lot"] }
 naga = { version = "30.0.1", default-features = false, features = ["wgsl-in"] }
 

--- a/mixer/Cargo.toml
+++ b/mixer/Cargo.toml
@@ -21,7 +21,7 @@ tokio.workspace = true
 bytemuck = { version = "1.25", features = ["derive"] }
 fontdue = "0.9"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "2e57ca89e0af4ca9f4e9642c72f26c0d0b1eef64", features = ["wgpu"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "413667f50ad45de139e5e063875047043a89cba4", features = ["wgpu"] }
 pollster = "0.4"
 raw-window-handle = "0.6"
 base64 = "0.22"
@@ -30,7 +30,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tiny_http = "0.12"
 vmix-core = { git = "https://github.com/MikanseiLaboratory/vmix-rs", features = ["xml", "std"] }
-vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "e6cccd45bf6bb0fb6b0617ccc55c74ea4a03c657" }
+vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs", rev = "5d9381745745870143cd7b477f0c5649accec7f7" }
 wgpu = { version = "30.0.1", default-features = false, features = ["std", "wgsl", "parking_lot"] }
 naga = { version = "30.0.1", default-features = false, features = ["wgsl-in"] }
 

--- a/mixer/src/lib.rs
+++ b/mixer/src/lib.rs
@@ -476,11 +476,23 @@ impl OutputHandle {
         pts: i64,
         fps_n: u32,
         fps_d: u32,
+        busy: Arc<AtomicBool>,
     ) -> Result<(), String> {
         match self {
-            Self::Omt(sender) => {
-                sender.send_video_texture(omt_gpu, texture, width, height, pts, fps_n, fps_d)
+            Self::Omt(sender) => sender.send_video_texture(
+                omt_gpu, texture, width, height, pts, fps_n, fps_d, busy,
+            ),
+            #[cfg(any(windows, target_os = "macos"))]
+            Self::Ndi(_) => {
+                busy.store(false, Ordering::Release);
+                Ok(())
             }
+        }
+    }
+
+    fn flush_gpu_encode(&mut self, omt_gpu: &OmtGpu) -> Result<(), String> {
+        match self {
+            Self::Omt(sender) => sender.flush_gpu_encode(omt_gpu),
             #[cfg(any(windows, target_os = "macos"))]
             Self::Ndi(_) => Ok(()),
         }

--- a/mixer/src/omt.rs
+++ b/mixer/src/omt.rs
@@ -289,6 +289,7 @@ pub struct ProgramSender {
     audio_ingress: AudioIngress,
     name: String,
     advertised: bool,
+    pending_gpu_busy: Option<Arc<AtomicBool>>,
 }
 
 /// Process-wide DNS-SD handle. Per-sender `Discovery` Drop would withdraw the
@@ -371,8 +372,9 @@ pub fn abandon_advertise(name: &str) {
 
 impl ProgramSender {
     pub fn start(name: &str) -> Result<Self, String> {
-        let sender = Sender::create(name, FrameType::VIDEO | FrameType::AUDIO)
+        let mut sender = Sender::create(name, FrameType::VIDEO | FrameType::AUDIO)
             .map_err(|error| error.to_string())?;
+        sender.set_gpu_encode_pipeline(true);
         let port = sender.port();
         let advertised = claim_advertise(name, port).is_ok();
         let audio_ingress = sender.audio_ingress();
@@ -382,6 +384,7 @@ impl ProgramSender {
             audio_ingress,
             name: name.to_string(),
             advertised,
+            pending_gpu_busy: None,
         })
     }
 
@@ -457,6 +460,7 @@ impl ProgramSender {
         pts: i64,
         fps_num: u32,
         fps_den: u32,
+        busy: Arc<AtomicBool>,
     ) -> Result<(), String> {
         let meta = VideoTextureMeta {
             width,
@@ -466,9 +470,32 @@ impl ProgramSender {
             frame_rate_d: fps_den as i32,
             ..Default::default()
         };
-        self.sender
+        let result = self
+            .sender
             .send_video_texture(ctx, texture, meta)
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string());
+        self.release_pending_gpu();
+        if result.is_ok() {
+            self.pending_gpu_busy = Some(busy);
+        } else {
+            busy.store(false, Ordering::Release);
+        }
+        result
+    }
+
+    pub fn flush_gpu_encode(&mut self, ctx: &OmtGpu) -> Result<(), String> {
+        let result = self
+            .sender
+            .flush_gpu_encode(ctx)
+            .map_err(|e| e.to_string());
+        self.release_pending_gpu();
+        result
+    }
+
+    fn release_pending_gpu(&mut self) {
+        if let Some(busy) = self.pending_gpu_busy.take() {
+            busy.store(false, Ordering::Release);
+        }
     }
 
     pub fn video_subscribed(&self) -> bool {
@@ -522,6 +549,7 @@ pub(crate) fn omt_audio_send(ingress: AudioIngress) -> Arc<dyn Fn(AudioPacket) +
 
 impl Drop for ProgramSender {
     fn drop(&mut self) {
+        self.release_pending_gpu();
         if self.advertised {
             release_advertise(&self.name);
         }

--- a/mixer/src/output.rs
+++ b/mixer/src/output.rs
@@ -80,15 +80,15 @@ fn send_worker(
     let mut timed_n = 0u32;
     loop {
         if stop.load(Ordering::Relaxed) || crate::diag::is_fatal() {
-            drain_release_gpu(&rx, video.take());
+            stop_send_worker(&mut sender, &omt_gpu, &rx, video.take());
             return;
         }
         if !drain_ctrl(&rx, &mut last_cpu) {
-            drain_release_gpu(&rx, video.take());
+            stop_send_worker(&mut sender, &omt_gpu, &rx, video.take());
             return;
         }
         if !pump_one(&mut sender, &video_sub, &connections) {
-            drain_release_gpu(&rx, video.take());
+            stop_send_worker(&mut sender, &omt_gpu, &rx, video.take());
             return;
         }
         for packet in audio.drain() {
@@ -114,7 +114,7 @@ fn send_worker(
                 &mut timed_n,
                 output_id,
             ) {
-                drain_release_gpu(&rx, video.take());
+                stop_send_worker(&mut sender, &omt_gpu, &rx, video.take());
                 return;
             }
             continue;
@@ -122,6 +122,18 @@ fn send_worker(
         let wait = cursor.next_deadline(clock);
         sleep_until_deadline(wait, stop.as_ref());
     }
+}
+
+fn stop_send_worker(
+    sender: &mut OutputHandle,
+    omt_gpu: &OmtGpu,
+    rx: &mpsc::Receiver<SendCmd>,
+    extra: Option<SendCmd>,
+) {
+    if let Err(error) = sender.flush_gpu_encode(omt_gpu) {
+        crate::diag::error(&format!("omt flush gpu encode: {error}"));
+    }
+    drain_release_gpu(rx, extra);
 }
 
 fn drain_ctrl(rx: &mpsc::Receiver<SendCmd>, last_cpu: &mut Option<SendCmd>) -> bool {
@@ -325,13 +337,20 @@ pub(crate) fn apply_send_cmd(sender: &mut OutputHandle, cmd: SendCmd, omt_gpu: &
             busy,
         } => {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                sender.send_video_texture(omt_gpu, &texture, width, height, pts, fps_n, fps_d)
+                sender.send_video_texture(
+                    omt_gpu, &texture, width, height, pts, fps_n, fps_d, busy.clone(),
+                )
             })) {
                 Ok(Ok(())) => {}
-                Ok(Err(error)) => crate::diag::mark_fatal(format!("omt send texture: {error}")),
-                Err(_) => crate::diag::mark_fatal("omt send texture panicked"),
+                Ok(Err(error)) => {
+                    busy.store(false, Ordering::Release);
+                    crate::diag::mark_fatal(format!("omt send texture: {error}"));
+                }
+                Err(_) => {
+                    busy.store(false, Ordering::Release);
+                    crate::diag::mark_fatal("omt send texture panicked");
+                }
             }
-            busy.store(false, Ordering::Release);
         }
         SendCmd::Audio { packet } => {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {


### PR DESCRIPTION
## Summary
- Pin `openmediatransport-rs` to the merged encode-opt revision (`413667f`, [PR #42](https://github.com/MikanseiLaboratory/openmediatransport-rs/pull/42)).
- Pin `vmx-rs` to the merged fused CPU / opaque GPU encode revision (`5d93817`, [PR #25](https://github.com/MikanseiLaboratory/vmx-rs/pull/25)).
- No mixer API changes: CPU UYVY already calls `encode_uyvy` (now fused), and GPU texture send stays opaque unless `VideoFlags::ALPHA` is set.

## Test plan
- [ ] `cargo check -p eiviz_mixer`
- [ ] Start an OMT CPU output and confirm receivers still decode
- [ ] Start an OMT GPU output and confirm texture encode still works
- [ ] Confirm CI (fmt / clippy / mixer tests) is green